### PR TITLE
refact: init toolchain pom for all modules

### DIFF
--- a/hugegraph-client/pom.xml
+++ b/hugegraph-client/pom.xml
@@ -2,31 +2,22 @@
          xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
          xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
     <modelVersion>4.0.0</modelVersion>
+    <parent>
+        <groupId>org.apache.hugegraph</groupId>
+        <artifactId>hugegraph-toolchain</artifactId>
+        <version>${revision}</version>
+        <relativePath>../pom.xml</relativePath>
+    </parent>
 
-    <groupId>com.baidu.hugegraph</groupId>
     <artifactId>hugegraph-client</artifactId>
-    <version>2.1.0</version>
     <packaging>jar</packaging>
 
-    <name>hugegraph-client</name>
-    <url>https://github.com/hugegraph/hugegraph-client</url>
+    <name>${artifactId}}</name>
+    <url>https://github.com/apache/incubator-hugegraph-toolchain/tree/master/hugegraph-client</url>
     <description>
         hugegraph-client is a Java-written client of HugeGraph, providing
         operations of graph, schema, gremlin, variables and traversals etc.
     </description>
-
-    <parent>
-        <groupId>org.sonatype.oss</groupId>
-        <artifactId>oss-parent</artifactId>
-        <version>7</version>
-    </parent>
-    <licenses>
-        <license>
-            <name>The Apache Software License, Version 2.0</name>
-            <url>http://www.apache.org/licenses/LICENSE-2.0.txt</url>
-            <distribution>repo</distribution>
-        </license>
-    </licenses>
 
     <scm>
         <url>https://github.com/hugegraph/hugegraph-client</url>
@@ -34,25 +25,8 @@
         <developerConnection>https://github.com/hugegraph/hugegraph-client
         </developerConnection>
     </scm>
-    <developers>
-        <developer>
-            <name>lizhangmei</name>
-            <email>javaloveme@gmail.com</email>
-        </developer>
-        <developer>
-            <name>zhoney</name>
-            <email>zhangyi89817@126.com</email>
-        </developer>
-        <developer>
-            <name>liningrui</name>
-            <email>liningrui@vip.qq.com</email>
-        </developer>
-    </developers>
 
     <properties>
-        <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
-        <compiler.source>1.8</compiler.source>
-        <compiler.target>1.8</compiler.target>
         <hugegraph.common.version>2.1.0</hugegraph.common.version>
         <jersey.version>3.0.3</jersey.version>
         <mockito.version>2.8.47</mockito.version>

--- a/hugegraph-hubble/hubble-be/pom.xml
+++ b/hugegraph-hubble/hubble-be/pom.xml
@@ -3,17 +3,15 @@
          xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
          xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
     <parent>
+        <groupId>org.apache.hugegraph</groupId>
         <artifactId>hugegraph-hubble</artifactId>
-        <groupId>com.baidu.hugegraph</groupId>
-        <version>1.6.0</version>
+        <version>${revision}</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 
     <artifactId>hubble-be</artifactId>
 
     <properties>
-        <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
-        <java.version>1.8</java.version>
         <skip.dump>true</skip.dump>
         <app.host>localhost</app.host>
         <app.port>36320</app.port>
@@ -124,37 +122,6 @@
 
     <build>
         <plugins>
-            <plugin>
-                <groupId>org.codehaus.mojo</groupId>
-                <artifactId>license-maven-plugin</artifactId>
-                <version>1.19</version>
-                <executions>
-                    <execution>
-                        <id>default-cli</id>
-                        <configuration>
-                            <!-- Accept the pom module -->
-                            <acceptPomPackaging>true</acceptPomPackaging>
-                            <!-- Using the template which is grouped by License file -->
-                            <fileTemplate>/org/codehaus/mojo/license/third-party-file-groupByMultiLicense.ftl</fileTemplate>
-                            <licenseMerges>
-                                <licenseMerge>The Apache Software License, Version 2.0|The Apache License, Version 2.0</licenseMerge>
-                                <licenseMerge>The Apache Software License, Version 2.0|Apache License, Version 2.0</licenseMerge>
-                                <licenseMerge>The Apache Software License, Version 2.0|Apache Public License 2.0</licenseMerge>
-                                <licenseMerge>The Apache Software License, Version 2.0|Apache 2</licenseMerge>
-                                <licenseMerge>The Apache Software License, Version 2.0|Apache 2.0</licenseMerge>
-                                <licenseMerge>The Apache Software License, Version 2.0|Apache-2.0</licenseMerge>
-                                <licenseMerge>The Apache Software License, Version 2.0|Apache License 2.0</licenseMerge>
-                                <licenseMerge>The Apache Software License, Version 2.0|Apache License, version 2.0</licenseMerge>
-                                <licenseMerge>3-Clause BSD License|BSD 3-clause</licenseMerge>
-                                <licenseMerge>3-Clause BSD License|BSD 3-Clause</licenseMerge>
-                                <licenseMerge>Eclipse Public License v1.0|Eclipse Public License 1.0</licenseMerge>
-                                <licenseMerge>Eclipse Public License v1.0|Eclipse Public License - v 1.0</licenseMerge>
-                                <licenseMerge>The MIT License|MIT License</licenseMerge>
-                            </licenseMerges>
-                        </configuration>
-                    </execution>
-                </executions>
-            </plugin>
             <!--
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>

--- a/hugegraph-hubble/hubble-dist/pom.xml
+++ b/hugegraph-hubble/hubble-dist/pom.xml
@@ -2,24 +2,23 @@
 <project xmlns="http://maven.apache.org/POM/4.0.0"
          xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
          xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
-    <parent>
-        <artifactId>hugegraph-hubble</artifactId>
-        <groupId>com.baidu.hugegraph</groupId>
-        <version>1.6.0</version>
-    </parent>
     <modelVersion>4.0.0</modelVersion>
+    <parent>
+        <groupId>org.apache.hugegraph</groupId>
+        <artifactId>hugegraph-hubble</artifactId>
+        <version>${revision}</version>
+    </parent>
 
     <artifactId>hubble-dist</artifactId>
 
     <properties>
-        <release.name>hugegraph-hubble</release.name>
+        <release.name>${artifactId}</release.name>
         <final.name>${release.name}-${project.version}</final.name>
         <top.level.basedir>${project.basedir}/..</top.level.basedir>
         <assembly.dir>${project.basedir}/assembly</assembly.dir>
         <assembly.descriptor.dir>${assembly.dir}/descriptor</assembly.descriptor.dir>
         <assembly.static.dir>${assembly.dir}/static</assembly.static.dir>
         <hubble-fe.dir>${top.level.basedir}/hubble-fe</hubble-fe.dir>
-        <shell-executable>bash</shell-executable>
     </properties>
 
     <dependencies>

--- a/hugegraph-hubble/pom.xml
+++ b/hugegraph-hubble/pom.xml
@@ -2,18 +2,24 @@
 <project xmlns="http://maven.apache.org/POM/4.0.0"
          xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
          xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
-    <parent>
-        <groupId>org.springframework.boot</groupId>
-        <artifactId>spring-boot-starter-parent</artifactId>
-        <version>2.1.8.RELEASE</version>
-        <relativePath/>
-    </parent>
     <modelVersion>4.0.0</modelVersion>
+    <parent>
+        <groupId>org.apache.hugegraph</groupId>
+        <artifactId>hugegraph-toolchain</artifactId>
+        <version>${revision}</version>
+        <relativePath>../pom.xml</relativePath>
+    </parent>
 
-    <groupId>com.baidu.hugegraph</groupId>
     <artifactId>hugegraph-hubble</artifactId>
     <packaging>pom</packaging>
-    <version>1.6.0</version>
+
+    <name>${artifactId}}</name>
+    <url>https://github.com/apache/incubator-hugegraph-toolchain/tree/master/hugegraph-hubble</url>
+    <description>
+        hugegraph-hubble is a graph management and analysis platform that provides features:
+        graph data load, schema management, graph relationship analysis and graphical display.
+    </description>
+
     <modules>
         <module>hubble-be</module>
         <module>hubble-dist</module>
@@ -22,5 +28,15 @@
     <properties>
         <top.level.dir>${project.basedir}/..</top.level.dir>
     </properties>
+
+    <dependencies>
+        <dependency>
+            <groupId>org.springframework.boot</groupId>
+            <artifactId>spring-boot-dependencies</artifactId>
+            <version>2.1.8.RELEASE</version>
+            <type>pom</type>
+            <scope>import</scope>
+        </dependency>
+    </dependencies>
 
 </project>

--- a/hugegraph-tools/pom.xml
+++ b/hugegraph-tools/pom.xml
@@ -2,23 +2,26 @@
          xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
          xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
     <modelVersion>4.0.0</modelVersion>
+    <parent>
+        <groupId>org.apache.hugegraph</groupId>
+        <artifactId>hugegraph-toolchain</artifactId>
+        <version>${revision}</version>
+        <relativePath>../pom.xml</relativePath>
+    </parent>
 
-    <groupId>com.baidu.xbu-data</groupId>
     <artifactId>hugegraph-tools</artifactId>
-    <version>1.6.0</version>
     <packaging>jar</packaging>
-    <url>http://maven.apache.org</url>
-    <name>${project.artifactId}</name>
+
+    <url>https://github.com/apache/incubator-hugegraph-toolchain/tree/master/hugegraph-tools</url>
+    <name>${artifactId}</name>
 
     <properties>
-        <release.name>hugegraph-tools</release.name>
+        <release.name>${artifactId}</release.name>
         <final.name>${release.name}-${project.version}</final.name>
         <assembly.dir>${project.basedir}/assembly</assembly.dir>
         <assembly.descriptor.dir>${assembly.dir}/descriptor</assembly.descriptor.dir>
         <shell-executable>bash</shell-executable>
         <junit.version>4.12</junit.version>
-        <java.version>1.8</java.version>
-        <source.encoding>UTF-8</source.encoding>
         <maven.build.timestamp.format>yyyy-MM-dd HH:mm:ssZ</maven.build.timestamp.format>
         <hugegraph-client-version>2.0.1</hugegraph-client-version>
         <jcommand-version>1.72</jcommand-version>
@@ -154,44 +157,13 @@
         <!--<testOutputDirectory>output/test-classes</testOutputDirectory>-->
         <plugins>
             <plugin>
-                <groupId>org.codehaus.mojo</groupId>
-                <artifactId>license-maven-plugin</artifactId>
-                <version>1.19</version>
-                <executions>
-                    <execution>
-                        <id>default-cli</id>
-                        <configuration>
-                            <!-- Accept the pom module -->
-                            <acceptPomPackaging>true</acceptPomPackaging>
-                            <!-- Using the template which is grouped by License file -->
-                            <fileTemplate>/org/codehaus/mojo/license/third-party-file-groupByMultiLicense.ftl</fileTemplate>
-                            <licenseMerges>
-                                <licenseMerge>The Apache Software License, Version 2.0|The Apache License, Version 2.0</licenseMerge>
-                                <licenseMerge>The Apache Software License, Version 2.0|Apache License, Version 2.0</licenseMerge>
-                                <licenseMerge>The Apache Software License, Version 2.0|Apache Public License 2.0</licenseMerge>
-                                <licenseMerge>The Apache Software License, Version 2.0|Apache 2</licenseMerge>
-                                <licenseMerge>The Apache Software License, Version 2.0|Apache 2.0</licenseMerge>
-                                <licenseMerge>The Apache Software License, Version 2.0|Apache-2.0</licenseMerge>
-                                <licenseMerge>The Apache Software License, Version 2.0|Apache License 2.0</licenseMerge>
-                                <licenseMerge>The Apache Software License, Version 2.0|Apache License, version 2.0</licenseMerge>
-                                <licenseMerge>3-Clause BSD License|BSD 3-clause</licenseMerge>
-                                <licenseMerge>3-Clause BSD License|BSD 3-Clause</licenseMerge>
-                                <licenseMerge>Eclipse Public License v1.0|Eclipse Public License 1.0</licenseMerge>
-                                <licenseMerge>Eclipse Public License v1.0|Eclipse Public License - v 1.0</licenseMerge>
-                                <licenseMerge>The MIT License|MIT License</licenseMerge>
-                            </licenseMerges>
-                        </configuration>
-                    </execution>
-                </executions>
-            </plugin>
-            <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-compiler-plugin</artifactId>
                 <version>3.7.0</version>
                 <configuration>
                     <source>${java.version}</source>
                     <target>${java.version}</target>
-                    <encoding>${source.encoding}</encoding>
+                    <encoding>${project.build.sourceEncoding}</encoding>
                 </configuration>
             </plugin>
             <plugin>

--- a/pom.xml
+++ b/pom.xml
@@ -3,50 +3,62 @@
          xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
          xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
     <modelVersion>4.0.0</modelVersion>
-    <parent>
-        <groupId>org.apache.hugegraph</groupId>
-        <artifactId>hugegraph-toolchain</artifactId>
-        <version>${revision}</version>
-        <relativePath>../pom.xml</relativePath>
-    </parent>
 
-    <artifactId>hugegraph-loader</artifactId>
-    <packaging>jar</packaging>
+    <groupId>org.apache.hugegraph</groupId>
+    <artifactId>hugegraph-toolchain</artifactId>
+    <version>${revision}</version>
+    <packaging>pom</packaging>
 
-    <name>${artifactId}</name>
-    <url>https://github.com/apache/incubator-hugegraph-toolchain/tree/master/hugegraph-loader</url>
+    <name>${project.artifactId}</name>
+    <url>https://github.com/apache/incubator-hugegraph-toolchain</url>
     <description>
-        hugegraph-loader is a customizable command line utility for loading small to medium size graph datasets
-        into the HugeGraph database from multiple data sources with various input formats.
+        hugegraph-toolchain is the integration project of a series of utilities for HugeGraph, it includes 4 main modules (loader/hubble/tools/client)
     </description>
 
+    <parent>
+        <groupId>org.sonatype.oss</groupId>
+        <artifactId>oss-parent</artifactId>
+        <version>7</version>
+    </parent>
+
+    <licenses>
+        <license>
+            <name>The Apache Software License, Version 2.0</name>
+            <url>http://www.apache.org/licenses/LICENSE-2.0.txt</url>
+            <distribution>repo</distribution>
+        </license>
+    </licenses>
+
+    <!-- TODO: we need update the url and all package together  -->
     <scm>
-        <url>https://github.com/hugegraph/hugegraph-loader</url>
-        <connection>https://github.com/hugegraph/hugegraph-loader</connection>
-        <developerConnection>https://github.com/hugegraph/hugegraph-loader
+        <url>https://github.com/hugegraph/hugegraph-toolchain</url>
+        <connection>https://github.com/hugegraph/hugegraph-toolchain</connection>
+        <developerConnection>https://github.com/hugegraph/hugegraph-toolchain
         </developerConnection>
     </scm>
 
+    <modules>
+        <module>hugegraph-client</module>
+        <module>hugegraph-hubble</module>
+        <module>hugegraph-loader</module>
+        <module>hugegraph-tools</module>
+    </modules>
+
     <properties>
-        <release.name>${artifactId}</release.name>
+        <revision>1.0.0</revision>
+        <release.name>${project.artifactId}</release.name>
         <final.name>${release.name}-${project.version}</final.name>
         <assembly.dir>${project.basedir}/assembly</assembly.dir>
         <assembly.descriptor.dir>${assembly.dir}/descriptor</assembly.descriptor.dir>
         <assembly.static.dir>${assembly.dir}/static</assembly.static.dir>
+        <shell-executable>bash</shell-executable>
+        <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
+        <java.version>1.8</java.version>
+        <compiler.source>1.8</compiler.source>
+        <compiler.target>1.8</compiler.target>
     </properties>
 
     <dependencies>
-        <dependency>
-            <groupId>com.baidu.hugegraph</groupId>
-            <artifactId>hugegraph-client</artifactId>
-            <version>2.0.1</version>
-            <exclusions>
-                <exclusion>
-                    <groupId>com.google.guava</groupId>
-                    <artifactId>guava</artifactId>
-                </exclusion>
-            </exclusions>
-        </dependency>
         <dependency>
             <groupId>commons-io</groupId>
             <artifactId>commons-io</artifactId>
@@ -78,55 +90,6 @@
             <version>29.0-jre</version>
         </dependency>
 
-        <!-- hadoop dependency -->
-        <dependency>
-            <groupId>org.apache.hadoop</groupId>
-            <artifactId>hadoop-common</artifactId>
-            <version>2.8.5</version>
-            <exclusions>
-                <exclusion>
-                    <groupId>org.slf4j</groupId>
-                    <artifactId>slf4j-api</artifactId>
-                </exclusion>
-                <exclusion>
-                    <groupId>org.slf4j</groupId>
-                    <artifactId>slf4j-log4j12</artifactId>
-                </exclusion>
-                <exclusion>
-                    <groupId>log4j</groupId>
-                    <artifactId>log4j</artifactId>
-                </exclusion>
-                <exclusion>
-                    <groupId>javax.ws.rs</groupId>
-                    <artifactId>jsr311-api</artifactId>
-                </exclusion>
-                <exclusion>
-                    <groupId>com.sun.jersey</groupId>
-                    <artifactId>jersey-server</artifactId>
-                </exclusion>
-                <exclusion>
-                    <groupId>com.sun.jersey</groupId>
-                    <artifactId>jersey-core</artifactId>
-                </exclusion>
-                <exclusion>
-                    <groupId>com.sun.jersey</groupId>
-                    <artifactId>jersey-servlet</artifactId>
-                </exclusion>
-                <exclusion>
-                    <groupId>com.sun.jersey</groupId>
-                    <artifactId>jersey-json</artifactId>
-                </exclusion>
-                <exclusion>
-                    <groupId>org.apache.commons</groupId>
-                    <artifactId>commons-compress</artifactId>
-                </exclusion>
-            </exclusions>
-        </dependency>
-        <dependency>
-            <groupId>org.apache.hadoop</groupId>
-            <artifactId>hadoop-hdfs-client</artifactId>
-            <version>2.8.5</version>
-        </dependency>
         <!--
         <dependency>
             <groupId>com.baidu.inf.hadoop</groupId>
@@ -380,6 +343,37 @@
 
     <build>
         <plugins>
+            <plugin>
+                <groupId>org.codehaus.mojo</groupId>
+                <artifactId>license-maven-plugin</artifactId>
+                <version>1.19</version>
+                <executions>
+                    <execution>
+                        <id>default-cli</id>
+                        <configuration>
+                            <!-- Accept the pom module -->
+                            <acceptPomPackaging>true</acceptPomPackaging>
+                            <!-- Using the template which is grouped by License file -->
+                            <fileTemplate>/org/codehaus/mojo/license/third-party-file-groupByMultiLicense.ftl</fileTemplate>
+                            <licenseMerges>
+                                <licenseMerge>The Apache Software License, Version 2.0|The Apache License, Version 2.0</licenseMerge>
+                                <licenseMerge>The Apache Software License, Version 2.0|Apache License, Version 2.0</licenseMerge>
+                                <licenseMerge>The Apache Software License, Version 2.0|Apache Public License 2.0</licenseMerge>
+                                <licenseMerge>The Apache Software License, Version 2.0|Apache 2</licenseMerge>
+                                <licenseMerge>The Apache Software License, Version 2.0|Apache 2.0</licenseMerge>
+                                <licenseMerge>The Apache Software License, Version 2.0|Apache-2.0</licenseMerge>
+                                <licenseMerge>The Apache Software License, Version 2.0|Apache License 2.0</licenseMerge>
+                                <licenseMerge>The Apache Software License, Version 2.0|Apache License, version 2.0</licenseMerge>
+                                <licenseMerge>3-Clause BSD License|BSD 3-clause</licenseMerge>
+                                <licenseMerge>3-Clause BSD License|BSD 3-Clause</licenseMerge>
+                                <licenseMerge>Eclipse Public License v1.0|Eclipse Public License 1.0</licenseMerge>
+                                <licenseMerge>Eclipse Public License v1.0|Eclipse Public License - v 1.0</licenseMerge>
+                                <licenseMerge>The MIT License|MIT License</licenseMerge>
+                            </licenseMerges>
+                        </configuration>
+                    </execution>
+                </executions>
+            </plugin>
             <plugin>
                 <artifactId>maven-compiler-plugin</artifactId>
                 <version>3.1</version>


### PR DESCRIPTION
Done:
- [x] rename groupId to `org.apache.hugegraph`
- [x] use a new version `1.0.0` for all modules 
- [x] add/delete some info & update urls
- [x] refer maven guid to unify all submodule with a ${revision} property to avoid useless version change
- [ ] run ci  (in another pr)
- [ ] remove duplicate import (in another pr)


TODO: improve the pom should be careful, it may cause a string of problems:)