### PR TITLE
Unify CI job names in the format 'xx-ci'

### DIFF
--- a/.github/workflows/client-ci.yml
+++ b/.github/workflows/client-ci.yml
@@ -23,7 +23,7 @@ on:
       - pom.xml
 
 jobs:
-  build:
+  client-ci:
     runs-on: ubuntu-20.04
     env:
       TRAVIS_DIR: hugegraph-client/assembly/travis


### PR DESCRIPTION
Unify CI job names in the format 'xx-ci' instead of 'build'