### PR TITLE
fix `port input` placeholder bug

### DIFF
--- a/hugegraph-hubble/hubble-fe/src/components/graph-management/NewGraphConfig.tsx
+++ b/hugegraph-hubble/hubble-fe/src/components/graph-management/NewGraphConfig.tsx
@@ -148,7 +148,7 @@ const NewGraphConfig: React.FC = observer(() => {
             <span>{t('addition.newGraphConfig.port')}:</span>
             <Input
               {...isRequiredInputProps}
-              placeholder={t('addition.newGraphConfig.host-desc')}
+              placeholder={t('addition.newGraphConfig.port-desc')}
               errorMessage={
                 graphManagementStore.isValidated &&
                 graphManagementStore.validateErrorMessage.port !== ''


### PR DESCRIPTION
fix the placeholder of the `port input` form, as it was use the wrong description of `host`.