### PR TITLE
fix: too many vertices for one time post in spark-loader

### DIFF
--- a/hugegraph-loader/src/main/java/com/baidu/hugegraph/loader/flink/HugeGraphOutputFormat.java
+++ b/hugegraph-loader/src/main/java/com/baidu/hugegraph/loader/flink/HugeGraphOutputFormat.java
@@ -139,7 +139,7 @@ public class HugeGraphOutputFormat<T> extends RichOutputFormat<T> {
             // Add batch
             List<String> graphElements = builder.getValue();
             graphElements.add(row.toString());
-            if (graphElements.size() > elementMapping.batchSize()) {
+            if (graphElements.size() >= elementMapping.batchSize()) {
                 flush(builder.getKey(), builder.getValue());
             }
         }

--- a/hugegraph-loader/src/main/java/com/baidu/hugegraph/loader/mapping/ElementMapping.java
+++ b/hugegraph-loader/src/main/java/com/baidu/hugegraph/loader/mapping/ElementMapping.java
@@ -67,7 +67,7 @@ public abstract class ElementMapping implements Checkable, Serializable {
         this.ignoredFields = new HashSet<>();
         this.nullValues = ImmutableSet.of(Constants.EMPTY_STR);
         this.updateStrategies = new HashMap<>();
-        this.batchSize = 1000;
+        this.batchSize = 500;
     }
 
     public abstract ElemType type();

--- a/hugegraph-loader/src/main/java/com/baidu/hugegraph/loader/spark/HugeGraphSparkLoader.java
+++ b/hugegraph-loader/src/main/java/com/baidu/hugegraph/loader/spark/HugeGraphSparkLoader.java
@@ -133,7 +133,7 @@ public class HugeGraphSparkLoader implements Serializable {
 
             // Insert
             List<GraphElement> graphElements = builderMap.getValue();
-            if (graphElements.size() > elementMapping.batchSize() ||
+            if (graphElements.size() >= elementMapping.batchSize() ||
                 (!p.hasNext() && graphElements.size() > 0)) {
                 flush(builderMap, context.client().graph(), this.loadOptions.checkVertex);
             }

--- a/hugegraph-loader/src/test/java/com/baidu/hugegraph/loader/test/unit/MappingConverterTest.java
+++ b/hugegraph-loader/src/test/java/com/baidu/hugegraph/loader/test/unit/MappingConverterTest.java
@@ -99,7 +99,7 @@ public class MappingConverterTest {
                 "\"value_mapping\":{},\"selected\":[]," +
                 "\"ignored\":[\"Occupation\",\"Zip-code\",\"Gender\"," +
                 "\"Age\"],\"null_values\":[\"\"]," +
-                "\"update_strategies\":{},\"batch_size\":1000}],\"edges\":[]},{\"id\":\"2\"," +
+                "\"update_strategies\":{},\"batch_size\":500}],\"edges\":[]},{\"id\":\"2\"," +
                 "\"skip\":false,\"input\":{\"type\":\"FILE\"," +
                 "\"path\":\"ratings.dat\"," +
                 "\"file_filter\":{\"extensions\":[\"*\"]}," +
@@ -116,7 +116,7 @@ public class MappingConverterTest {
                 "\"field_mapping\":{\"UserID\":\"id\",\"MovieID\":\"id\"," +
                 "\"Rating\":\"rate\"},\"value_mapping\":{},\"selected\":[]," +
                 "\"ignored\":[\"Timestamp\"],\"null_values\":[\"\"]," +
-                "\"update_strategies\":{},\"batch_size\":1000}]}]}";
+                "\"update_strategies\":{},\"batch_size\":500}]}]}";
         Assert.assertEquals(expectV2Json, actualV2Json);
 
         FileUtils.forceDelete(inputFile);


### PR DESCRIPTION

The option `batch.max_vertices_per_batch` default value is 500, if spark/flink default value of `batch_size` is bigger than 500 ,will cause the below exception.

``` shell
class java.lang.IllegalArgumentException: Too many vertices for one time post, the maximum number is '500'
  at com.baidu.hugegraph.exception.ServerException.fromResponse(ServerException.java:47)
  at com.baidu.hugegraph.client.RestClient.checkStatus(RestClient.java:93)
  at com.baidu.hugegraph.rest.AbstractRestClient.post(AbstractRestClient.java:231)
  at com.baidu.hugegraph.rest.AbstractRestClient.post(AbstractRestClient.java:211)
  at com.baidu.hugegraph.api.graph.VertexAPI.create(VertexAPI.java:58)
  at com.baidu.hugegraph.driver.GraphManager.addVertices(GraphManager.java:96)
  at com.baidu.hugegraph.loader.spark.HugeGraphSparkLoader.flush(HugeGraphSparkLoader.java:253)
  at com.baidu.hugegraph.loader.spark.HugeGraphSparkLoader.loadRow(HugeGraphSparkLoader.java:150)
  at com.baidu.hugegraph.loader.spark.HugeGraphSparkLoader.lambda$null$0(HugeGraphSparkLoader.java:111)
```

closed #311 