### PR TITLE
fix: schema not cached in spark/flink loader

### DIFF
--- a/hugegraph-loader/src/main/java/com/baidu/hugegraph/loader/builder/SchemaCache.java
+++ b/hugegraph-loader/src/main/java/com/baidu/hugegraph/loader/builder/SchemaCache.java
@@ -46,6 +46,7 @@ public final class SchemaCache {
         this.propertyKeys = new HashMap<>();
         this.vertexLabels = new HashMap<>();
         this.edgeLabels = new HashMap<>();
+        updateAll();
     }
 
     @JsonCreator
@@ -90,6 +91,7 @@ public final class SchemaCache {
         if (propertyKey == null) {
             try {
                 propertyKey = this.client.schema().getPropertyKey(name);
+                updateAll();
             } catch (ServerException e) {
                 throw new LoadException("The property key '%s' doesn't exist",
                                         name);
@@ -103,6 +105,7 @@ public final class SchemaCache {
         if (vertexLabel == null) {
             try {
                 vertexLabel = this.client.schema().getVertexLabel(name);
+                updateAll();
             } catch (ServerException e) {
                 throw new LoadException("The vertex label '%s' doesn't exist",
                                         name);
@@ -116,6 +119,7 @@ public final class SchemaCache {
         if (edgeLabel == null) {
             try {
                 edgeLabel = this.client.schema().getEdgeLabel(name);
+                updateAll();
             } catch (ServerException e) {
                 throw new LoadException("The edge label '%s' doesn't exist",
                                         name);

--- a/hugegraph-loader/src/main/java/com/baidu/hugegraph/loader/builder/SchemaCache.java
+++ b/hugegraph-loader/src/main/java/com/baidu/hugegraph/loader/builder/SchemaCache.java
@@ -46,7 +46,6 @@ public final class SchemaCache {
         this.propertyKeys = new HashMap<>();
         this.vertexLabels = new HashMap<>();
         this.edgeLabels = new HashMap<>();
-        updateAll();
     }
 
     @JsonCreator
@@ -91,7 +90,6 @@ public final class SchemaCache {
         if (propertyKey == null) {
             try {
                 propertyKey = this.client.schema().getPropertyKey(name);
-                updateAll();
             } catch (ServerException e) {
                 throw new LoadException("The property key '%s' doesn't exist",
                                         name);
@@ -105,7 +103,6 @@ public final class SchemaCache {
         if (vertexLabel == null) {
             try {
                 vertexLabel = this.client.schema().getVertexLabel(name);
-                updateAll();
             } catch (ServerException e) {
                 throw new LoadException("The vertex label '%s' doesn't exist",
                                         name);
@@ -119,7 +116,6 @@ public final class SchemaCache {
         if (edgeLabel == null) {
             try {
                 edgeLabel = this.client.schema().getEdgeLabel(name);
-                updateAll();
             } catch (ServerException e) {
                 throw new LoadException("The edge label '%s' doesn't exist",
                                         name);

--- a/hugegraph-loader/src/main/java/com/baidu/hugegraph/loader/flink/HugeGraphOutputFormat.java
+++ b/hugegraph-loader/src/main/java/com/baidu/hugegraph/loader/flink/HugeGraphOutputFormat.java
@@ -90,6 +90,7 @@ public class HugeGraphOutputFormat<T> extends RichOutputFormat<T> {
             builders.put(new EdgeBuilder(loadContext, this.struct, edgeMapping),
                          new ArrayList<>());
         }
+        loadContext.updateSchemaCache();
         return builders;
     }
 

--- a/hugegraph-loader/src/main/java/com/baidu/hugegraph/loader/spark/HugeGraphSparkLoader.java
+++ b/hugegraph-loader/src/main/java/com/baidu/hugegraph/loader/spark/HugeGraphSparkLoader.java
@@ -117,6 +117,7 @@ public class HugeGraphSparkLoader implements Serializable {
             this.builders.put(new EdgeBuilder(context, struct, edgeMapping),
                               new ArrayList<>());
         }
+        context.updateSchemaCache();
         return context;
     }
 


### PR DESCRIPTION
SchemaCache init and after query schema then put the latest schema to SchemaCache

I have read the CLA Document and I hereby sign the CLA