### PR TITLE
Add maven-clean-plugin for hubble

### DIFF
--- a/hugegraph-dist/pom.xml
+++ b/hugegraph-dist/pom.xml
@@ -34,12 +34,10 @@
                                     ls ${project.parent.basedir}/hugegraph-loader/*
                                     ls ${project.parent.basedir}/hugegraph-tools/*
 
-                                    \cp -r ${project.parent.basedir}/hugegraph-hubble/hugegraph-hubble ${project.basedir}
-                                    \cp -r ${project.parent.basedir}/hugegraph-loader/hugegraph-loader-${project.version} ${project.basedir}
-                                    \cp -r ${project.parent.basedir}/hugegraph-tools/hugegraph-tools-${project.version} ${project.basedir}
-
                                     tar -zcvf ${project.parent.basedir}/${final.name}.tar.gz \
-                                    hugegraph-hubble hugegraph-loader-* hugegraph-tools-* || exit 1
+                                    ${project.parent.basedir}/hugegraph-hubble/hugegraph-hubble \
+                                    ${project.parent.basedir}/hugegraph-loader/hugegraph-loader-${project.version} \
+                                    ${project.parent.basedir}/hugegraph-tools/hugegraph-tools-${project.version} || exit 1
 
                                     md5sum ${project.parent.basedir}/${final.name}.tar.gz
                                     echo -n "hugegraph-toolchain tar.gz available at: "

--- a/hugegraph-hubble/pom.xml
+++ b/hugegraph-hubble/pom.xml
@@ -41,4 +41,23 @@
         </dependencies>
     </dependencyManagement>
 
+    <build>
+        <plugins>
+            <plugin>
+                <artifactId>maven-clean-plugin</artifactId>
+                <version>3.0.0</version>
+                <configuration>
+                    <filesets>
+                        <fileset>
+                            <directory>${project.artifactId}</directory>
+                        </fileset>
+                        <fileset>
+                            <directory>hubble-dist/${project.artifactId}</directory>
+                        </fileset>
+                    </filesets>
+                </configuration>
+            </plugin>
+        </plugins>
+    </build>
+
 </project>


### PR DESCRIPTION
Avoid creating too many temporary files by `cp` and add `maven-clean-plugin` for hubble to clean package files.
