### PR TITLE
chore: fix hugegraph-dist package failed

### DIFF
--- a/hugegraph-dist/pom.xml
+++ b/hugegraph-dist/pom.xml
@@ -15,7 +15,6 @@
     <properties>
         <release.name>${project.parent.artifactId}</release.name>
         <final.name>${release.name}-${project.version}</final.name>
-        <top.level.dir>${project.basedir}/..</top.level.dir>
     </properties>
 
     <build>
@@ -31,19 +30,19 @@
                         <configuration>
                             <tasks>
                                 <echo file="${project.basedir}/dist.sh">
-                                    cd  ${top.level.dir}
-                                    ls ./hugegraph-hubble/*
-                                    ls ./hugegraph-loader/*
-                                    ls ./hugegraph-tools/*
+                                    root_path=$(cd $(dirname $0)/..; pwd)
+                                    cd $root_path
 
-                                    tar -zcvf ${top.level.dir}/${final.name}.tar.gz \
-                                    ./hugegraph-hubble/hugegraph-hubble \
-                                    ./hugegraph-loader/hugegraph-loader-${project.version} \
-                                   ./hugegraph-tools/hugegraph-tools-${project.version} || exit 1
+                                    mkdir -p ${final.name}
+                                    mv $root_path/hugegraph-hubble/hugegraph-hubble ${final.name}/hugegraph-hubble-${project.version}
+                                    mv $root_path/hugegraph-loader/hugegraph-loader-${project.version} ${final.name}/hugegraph-loader-${project.version}
+                                    mv $root_path/hugegraph-tools/hugegraph-tools-${project.version} ${final.name}/hugegraph-tools-${project.version}
 
-                                    md5sum ./${final.name}.tar.gz
+                                    tar -zcvf $root_path/${final.name}.tar.gz ./${final.name} || exit 1
+
+                                    md5sum $root_path/${final.name}.tar.gz
                                     echo -n "hugegraph-toolchain tar.gz available at: "
-                                    echo "${top.level.dir}/${final.name}.tar.gz"
+                                    echo "$root_path/${final.name}.tar.gz"
                                     rm -f ${project.basedir}/dist.sh
 
                                 </echo>
@@ -61,7 +60,7 @@
                 <configuration>
                     <filesets>
                         <fileset>
-                            <directory>${top.level.dir}</directory>
+                            <directory>${project.basedir}/..</directory>
                             <includes>
                                 <include>${final.name}.tar.gz</include>
                             </includes>

--- a/hugegraph-dist/pom.xml
+++ b/hugegraph-dist/pom.xml
@@ -31,16 +31,17 @@
                         <configuration>
                             <tasks>
                                 <echo file="${project.basedir}/dist.sh">
-                                    ls ${top.level.dir}/hugegraph-hubble/*
-                                    ls ${top.level.dir}/hugegraph-loader/*
-                                    ls ${top.level.dir}/hugegraph-tools/*
+                                    cd  ${top.level.dir}
+                                    ls ./hugegraph-hubble/*
+                                    ls ./hugegraph-loader/*
+                                    ls ./hugegraph-tools/*
 
                                     tar -zcvf ${top.level.dir}/${final.name}.tar.gz \
-                                    ${top.level.dir}/hugegraph-hubble/hugegraph-hubble \
-                                    ${top.level.dir}/hugegraph-loader/hugegraph-loader-${project.version} \
-                                    ${top.level.dir}/hugegraph-tools/hugegraph-tools-${project.version} || exit 1
+                                    ./hugegraph-hubble/hugegraph-hubble \
+                                    ./hugegraph-loader/hugegraph-loader-${project.version} \
+                                   ./hugegraph-tools/hugegraph-tools-${project.version} || exit 1
 
-                                    md5sum ${top.level.dir}/${final.name}.tar.gz
+                                    md5sum ./${final.name}.tar.gz
                                     echo -n "hugegraph-toolchain tar.gz available at: "
                                     echo "${top.level.dir}/${final.name}.tar.gz"
                                     rm -f ${project.basedir}/dist.sh

--- a/hugegraph-dist/pom.xml
+++ b/hugegraph-dist/pom.xml
@@ -15,6 +15,7 @@
     <properties>
         <release.name>${project.parent.artifactId}</release.name>
         <final.name>${release.name}-${project.version}</final.name>
+        <top.level.dir>${project.basedir}/..</top.level.dir>
     </properties>
 
     <build>
@@ -30,18 +31,18 @@
                         <configuration>
                             <tasks>
                                 <echo file="${project.basedir}/dist.sh">
-                                    ls ${project.parent.basedir}/hugegraph-hubble/*
-                                    ls ${project.parent.basedir}/hugegraph-loader/*
-                                    ls ${project.parent.basedir}/hugegraph-tools/*
+                                    ls ${top.level.dir}/hugegraph-hubble/*
+                                    ls ${top.level.dir}/hugegraph-loader/*
+                                    ls ${top.level.dir}/hugegraph-tools/*
 
-                                    tar -zcvf ${project.parent.basedir}/${final.name}.tar.gz \
-                                    ${project.parent.basedir}/hugegraph-hubble/hugegraph-hubble \
-                                    ${project.parent.basedir}/hugegraph-loader/hugegraph-loader-${project.version} \
-                                    ${project.parent.basedir}/hugegraph-tools/hugegraph-tools-${project.version} || exit 1
+                                    tar -zcvf ${top.level.dir}/${final.name}.tar.gz \
+                                    ${top.level.dir}/hugegraph-hubble/hugegraph-hubble \
+                                    ${top.level.dir}/hugegraph-loader/hugegraph-loader-${project.version} \
+                                    ${top.level.dir}/hugegraph-tools/hugegraph-tools-${project.version} || exit 1
 
-                                    md5sum ${project.parent.basedir}/${final.name}.tar.gz
+                                    md5sum ${top.level.dir}/${final.name}.tar.gz
                                     echo -n "hugegraph-toolchain tar.gz available at: "
-                                    echo "${project.parent.basedir}/${final.name}.tar.gz"
+                                    echo "${top.level.dir}/${final.name}.tar.gz"
                                     rm -f ${project.basedir}/dist.sh
 
                                 </echo>
@@ -59,7 +60,7 @@
                 <configuration>
                     <filesets>
                         <fileset>
-                            <directory>${project.parent.basedir}</directory>
+                            <directory>${top.level.dir}</directory>
                             <includes>
                                 <include>${final.name}.tar.gz</include>
                             </includes>


### PR DESCRIPTION
```
${project.parent.basedir}: bad substitution
```
refer to https://github.com/apache/incubator-hugegraph-toolchain/pull/339#issuecomment-1296676770

