### PR TITLE
Fix flaky tests in IndexLabelTest due to non deterministic JSON key ordering

### DIFF
--- a/hugegraph-client/src/test/java/org/apache/hugegraph/unit/IndexLabelTest.java
+++ b/hugegraph-client/src/test/java/org/apache/hugegraph/unit/IndexLabelTest.java
@@ -19,6 +19,8 @@
 
 package org.apache.hugegraph.unit;
 
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.databind.ObjectMapper;
 import org.junit.Test;
 
 import org.apache.hugegraph.exception.NotSupportException;
@@ -30,7 +32,7 @@ import org.apache.hugegraph.util.JsonUtil;
 public class IndexLabelTest {
 
     @Test
-    public void testIndexLabel() {
+    public void testIndexLabel() throws JsonProcessingException {
         IndexLabel.Builder builder = new IndexLabel.BuilderImpl("personByAge",
                                                                 null);
         IndexLabel indexLabel = builder.onV("person")
@@ -44,12 +46,13 @@ public class IndexLabelTest {
                       "\"base_value\":\"person\"," +
                       "\"index_type\":\"SECONDARY\",\"fields\":[\"age\"]," +
                       "\"rebuild\":true}";
-        Assert.assertEquals(json, JsonUtil.toJson(indexLabel));
+        ObjectMapper mapper = new ObjectMapper();
+        Assert.assertEquals(mapper.readTree(json), mapper.readTree(JsonUtil.toJson(indexLabel)));
         Assert.assertEquals(HugeType.INDEX_LABEL.string(), indexLabel.type());
     }
 
     @Test
-    public void testIndexLabelV49() {
+    public void testIndexLabelV49() throws JsonProcessingException {
         IndexLabel.Builder builder = new IndexLabel.BuilderImpl("personByAge",
                                                                 null);
         IndexLabel indexLabel = builder.onV("person")
@@ -63,7 +66,8 @@ public class IndexLabelTest {
                       "\"check_exist\":true,\"base_type\":\"VERTEX_LABEL\"," +
                       "\"base_value\":\"person\"," +
                       "\"index_type\":\"SECONDARY\",\"fields\":[\"age\"]}";
-        Assert.assertEquals(json, JsonUtil.toJson(indexLabelV49));
+        ObjectMapper mapper = new ObjectMapper();
+        Assert.assertEquals(mapper.readTree(json), mapper.readTree(JsonUtil.toJson(indexLabelV49)));
         Assert.assertEquals(HugeType.INDEX_LABEL.string(),
                             indexLabelV49.type());
 
@@ -71,7 +75,7 @@ public class IndexLabelTest {
     }
 
     @Test
-    public void testIndexLabelV56() {
+    public void testIndexLabelV56() throws JsonProcessingException {
         IndexLabel.Builder builder = new IndexLabel.BuilderImpl("personByAge",
                                                                 null);
         IndexLabel indexLabel = builder.onV("person")
@@ -85,7 +89,8 @@ public class IndexLabelTest {
                       "\"check_exist\":true,\"user_data\":{}," +
                       "\"base_type\":\"VERTEX_LABEL\",\"base_value\":\"person\"," +
                       "\"index_type\":\"SECONDARY\",\"fields\":[\"age\"]}";
-        Assert.assertEquals(json, JsonUtil.toJson(indexLabelV56));
+        ObjectMapper mapper = new ObjectMapper();
+        Assert.assertEquals(mapper.readTree(json), mapper.readTree(JsonUtil.toJson(indexLabelV56)));
         Assert.assertEquals(HugeType.INDEX_LABEL.string(),
                             indexLabelV56.type());
 


### PR DESCRIPTION
### Motivation
IndexLabelTest has the following tests that are flaky, detected using the [NonDex](https://github.com/TestingResearchIllinois/NonDex) tool:
org.apache.hugegraph.unit.IndexLabelTest#testIndexLabel
org.apache.hugegraph.unit.IndexLabelTest#testIndexLabelV49
org.apache.hugegraph.unit.IndexLabelTest#testIndexLabelV56

The tests fail due to non-deterministic ordering of the properties in the JSON string created by the `JsonUtil.toJson()` method.

### Command to reproduce
mvn -pl hugegraph-client edu.illinois:nondex-maven-plugin:2.1.1:nondex -Dtest=org.apache.hugegraph.unit.IndexLabelTest

### Log
```
[ERROR]   IndexLabelTest.testIndexLabel:47 expected:<...ame":"personByAge","[id":0,"check_exist":true,"user_data":{},"base_type":"VERTEX_LABEL","base_value":"person","index_type":"SECONDARY","fields":["age"],"rebuild":true]}> but was:<...ame":"personByAge","[check_exist":true,"user_data":{},"id":0,"fields":["age"],"base_value":"person","rebuild":true,"index_type":"SECONDARY","base_type":"VERTEX_LABEL"]}>

[ERROR]   IndexLabelTest.testIndexLabelV49:66 expected:<{"id":0,"[name":"personByAge","check_exist":true],"base_type":"VERTEX...> but was:<{"id":0,"[check_exist":true,"name":"personByAge"],"base_type":"VERTEX...>

[ERROR]   IndexLabelTest.testIndexLabelV56:88 expected:<{"[id":0,"name":"personByAge","check_exist":true,"user_data":{},"base_type":"VERTEX_LABEL","base_value":"person","index_type":"SECONDARY]","fields":["age"]}> but was:<{"[name":"personByAge","id":0,"check_exist":true,"user_data":{},"index_type":"SECONDARY","base_type":"VERTEX_LABEL","base_value":"person]","fields":["age"]}>
```

### Changes
Using the jackson ObjectMapper, comparing the JSONNodes instead of raw json strings would make the test deterministic, as the order of the properties will not be compared.