### PR TITLE
fix(loader): wrong shell symbol in spark script

### DIFF
--- a/hugegraph-loader/assembly/static/bin/hugegraph-spark-loader.sh
+++ b/hugegraph-loader/assembly/static/bin/hugegraph-spark-loader.sh
@@ -1,4 +1,4 @@
-)`:
+#!/bin/bash
 #
 # Licensed to the Apache Software Foundation (ASF) under one or more
 # contributor license agreements.  See the NOTICE file distributed with


### PR DESCRIPTION
fix spark loader sh error