### PR TITLE
Fix convert numbers to strings

### DIFF
--- a/hugegraph-loader/src/main/java/org/apache/hugegraph/loader/util/DataTypeUtil.java
+++ b/hugegraph-loader/src/main/java/org/apache/hugegraph/loader/util/DataTypeUtil.java
@@ -143,6 +143,10 @@ public final class DataTypeUtil {
             return parseDate(key, value, dateFormat, timeZone);
         } else if (dataType.isUUID()) {
             return parseUUID(key, value);
+        } else if (DataType.TEXT == dataType) {
+            if (!(rawValue instanceof String)) {
+                value = rawValue.toString();
+            }
         }
         E.checkArgument(checkDataType(key, value, dataType),
                         "The value(key='%s') '%s'(%s) is not match with " +
@@ -312,7 +316,7 @@ public final class DataTypeUtil {
      */
     private static boolean checkDataType(String key, Object value,
                                          DataType dataType) {
-        if (value instanceof Number) {
+        if (value instanceof Number && dataType.isNumber()) {
             return parseNumber(key, value, dataType) != null;
         }
         return dataType.clazz().isInstance(value);

--- a/hugegraph-loader/src/test/java/org/apache/hugegraph/loader/test/functional/JDBCLoadTest.java
+++ b/hugegraph-loader/src/test/java/org/apache/hugegraph/loader/test/functional/JDBCLoadTest.java
@@ -146,6 +146,7 @@ public class JDBCLoadTest extends LoadTest {
                 "-s", configPath("jdbc_customized_schema/schema.groovy"),
                 "-g", GRAPH,
                 "-h", SERVER,
+                "-p", String.valueOf(PORT),
                 "--batch-insert-threads", "2",
                 "--test-mode", "true"
         };
@@ -173,6 +174,7 @@ public class JDBCLoadTest extends LoadTest {
                 "-s", configPath("jdbc_customized_schema/schema.groovy"),
                 "-g", GRAPH,
                 "-h", SERVER,
+                "-p", String.valueOf(PORT),
                 "--batch-insert-threads", "2",
                 "--test-mode", "true"
         };
@@ -196,6 +198,7 @@ public class JDBCLoadTest extends LoadTest {
                 "-s", configPath("jdbc_value_mapping/schema.groovy"),
                 "-g", GRAPH,
                 "-h", SERVER,
+                "-p", String.valueOf(PORT),
                 "--batch-insert-threads", "2",
                 "--test-mode", "true"
         };
@@ -207,5 +210,37 @@ public class JDBCLoadTest extends LoadTest {
                        "age", 29, "city", "Beijing");
         assertContains(vertices, "person", "name", "vadas",
                        "age", 27, "city", "Shanghai");
+    }
+
+    @Test
+    public void testNumberToStringInJDBCSource() {
+        dbUtil.insert("INSERT INTO `person` VALUES " +
+                "(1,'marko',29,'Beijing')," +
+                "(2,'vadas',27,'HongKong')," +
+                "(3,'josh',32,'Beijing')," +
+                "(4,'peter',35,'Shanghai')," +
+                "(5,'li,nary',26,'Wu,han')," +
+                "(6,'tom',NULL,NULL);");
+
+        dbUtil.insert("INSERT INTO `software` VALUES " +
+                "(100,'lop','java',328.08)," +
+                "(200,'ripple','java',199.67);");
+
+        String[] args = new String[]{
+                "-f", configPath("jdbc_number_to_string/struct.json"),
+                "-s", configPath("jdbc_number_to_string/schema.groovy"),
+                "-g", GRAPH,
+                "-h", SERVER,
+                "-p", String.valueOf(PORT),
+                "--batch-insert-threads", "2",
+                "--test-mode", "true"
+        };
+        HugeGraphLoader.main(args);
+
+        List<Vertex> vertices = CLIENT.graph().listVertices();
+
+        Assert.assertEquals(8, vertices.size());
+        assertContains(vertices, "person", "age", "29");
+        assertContains(vertices, "software", "price", "199.67");
     }
 }

--- a/hugegraph-loader/src/test/resources/jdbc_number_to_string/schema.groovy
+++ b/hugegraph-loader/src/test/resources/jdbc_number_to_string/schema.groovy
@@ -1,0 +1,25 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements. See the NOTICE file distributed with this
+ * work for additional information regarding copyright ownership. The ASF
+ * licenses this file to You under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ */
+// Define schema
+schema.propertyKey("name").asText().ifNotExist().create();
+schema.propertyKey("age").asText().ifNotExist().create();
+schema.propertyKey("city").asText().ifNotExist().create();
+schema.propertyKey("lang").asText().ifNotExist().create();
+schema.propertyKey("price").asText().ifNotExist().create();
+
+schema.vertexLabel("person").useCustomizeNumberId().properties("name", "age", "city").nullableKeys("name", "age", "city").ifNotExist().create();
+schema.vertexLabel("software").useCustomizeNumberId().properties("name", "lang", "price").nullableKeys("name", "lang", "price").ifNotExist().create();

--- a/hugegraph-loader/src/test/resources/jdbc_number_to_string/struct.json
+++ b/hugegraph-loader/src/test/resources/jdbc_number_to_string/struct.json
@@ -1,0 +1,37 @@
+{
+  "vertices": [
+    {
+      "label": "person",
+      "input": {
+        "type": "jdbc",
+        "vendor": "mysql",
+        "driver": "com.mysql.cj.jdbc.Driver",
+        "url": "jdbc:mysql://127.0.0.1:3306",
+        "database": "load_test",
+        "table": "person",
+        "username": "root",
+        "password": "root",
+        "batch_size": 2
+      },
+      "id": "id",
+      "null_values": ["NULL"],
+      "ignored": ["name","city"]
+    },
+    {
+      "label": "software",
+      "input": {
+        "type": "jdbc",
+        "vendor": "mysql",
+        "driver": "com.mysql.cj.jdbc.Driver",
+        "url": "jdbc:mysql://127.0.0.1:3306",
+        "database": "load_test",
+        "table": "software",
+        "username": "root",
+        "password": "root",
+        "batch_size": 2
+      },
+      "id": "id",
+      "ignored": ["name","lang"]
+    }
+  ]
+}


### PR DESCRIPTION
- SubTask of #298
- Close #299

fix data type transfer when number in database but declare as text(string) in schema.

eg:

```
29         ->     "29"
199.67     ->     "199.67"
```

result(metrics log):

```
>> HugeGraphLoader worked in NORMAL MODE
vertices/edges loaded this time : 8/0
--------------------------------------------------
count metrics
    input read success            : 8                   
    input read failure            : 0                   
    vertex parse success          : 8                   
    vertex parse failure          : 0                   
    vertex insert success         : 8                   
    vertex insert failure         : 0                   
    edge parse success            : 0                   
    edge parse failure            : 0                   
    edge insert success           : 0                   
    edge insert failure           : 0                   
--------------------------------------------------
meter metrics
    total time                    : 0.062s              
    read time                     : 0.036s              
    load time                     : 0.026s              
    vertex load time              : 0.026s              
    vertex load rate(vertices/s)  : 307                 
    edge load time                : 0s                  
    edge load rate(edges/s)       : -1   
```

Local UTs:

<img width="247" alt="Snipaste_2023-05-18_02-26-59" src="https://github.com/apache/incubator-hugegraph-toolchain/assets/42756849/cd7de111-9cd5-4576-9da6-40506a58b02a">
