### PR TITLE
fix: hugegraph-spark-loader shell string length limit

### DIFF
--- a/hugegraph-loader/assembly/static/bin/hugegraph-spark-loader.sh
+++ b/hugegraph-loader/assembly/static/bin/hugegraph-spark-loader.sh
@@ -35,4 +35,4 @@ CMD="${SPARK_HOME}/bin/spark-submit
     --jars $(echo "${LIB_DIR}"/*.jar | tr ' ' ',') ${ASSEMBLY_JAR_NAME} ${HUGEGRAPH_PARAMS}"
 
 echo "${CMD}"
-exec "${CMD}"
+exec ${CMD}


### PR DESCRIPTION
fix #460
I have read the CLA Document and I hereby sign the CLA