### PR TITLE
fix yarn network connection on linux/arm64 arch

### DIFF
--- a/hugegraph-hubble/hubble-dist/pom.xml
+++ b/hugegraph-hubble/hubble-dist/pom.xml
@@ -81,7 +81,7 @@
                                 <echo file="${top.level.dir}/dist.sh">
                                     cd ${hubble-fe.dir} || exit 1
                                     export CI=false
-                                    yarn install &amp;&amp; yarn build || exit 1
+                                    yarn install --network-timeout 600000 &amp;&amp; yarn build || exit 1
                                     echo -e "Hubble-FE build successfully.\n"
 
                                     cd ${top.level.dir} &amp;&amp; pwd


### PR DESCRIPTION
yarn may frequently cause network connection on `linux/arm64` arch

```
#22 374.1 main:
#22 379.0      [exec] yarn install v1.22.19
#22 381.2      [exec] [1/4] Resolving packages...
#22 391.1      [exec] [2/4] Fetching packages...
#22 431.2      [exec] info There appears to be trouble with your network connection. Retrying...
#22 459.7      [exec] info There appears to be trouble with your network connection. Retrying...
#22 493.0      [exec] info There appears to be trouble with your network connection. Retrying...
#22 526.6      [exec] info There appears to be trouble with your network connection. Retrying...
#22 560.0      [exec] info There appears to be trouble with your network connection. Retrying...
```
refer to https://github.com/hugegraph/actions/actions/runs/6194003062/job/16817665758

Increasing the timeout can solve this problem, it has been verified on https://github.com/simon824/hugegraph-actions/actions/runs/6195873357/job/16821404664
refer to https://github.com/docker/build-push-action/issues/471#issuecomment-928456949
