### PR TITLE
chore: json util supply method to parse json list

### DIFF
--- a/hugegraph-client/src/main/java/org/apache/hugegraph/util/JsonUtil.java
+++ b/hugegraph-client/src/main/java/org/apache/hugegraph/util/JsonUtil.java
@@ -18,10 +18,12 @@
 package org.apache.hugegraph.util;
 
 import java.io.IOException;
+import java.util.List;
 
 import org.apache.hugegraph.rest.SerializeException;
 
 import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.databind.JavaType;
 import com.fasterxml.jackson.databind.JsonNode;
 import com.fasterxml.jackson.databind.Module;
 import com.fasterxml.jackson.databind.ObjectMapper;
@@ -59,5 +61,18 @@ public final class JsonUtil {
             throw new SerializeException("Failed to deserialize json node '%s'",
                                          e, node);
         }
+    }
+
+    public static <T> List<T> fromJson2List(String json, Class<T> clazz) {
+        try {
+            return MAPPER.readValue(json, getCollectionType(List.class, clazz));
+        } catch (IOException e) {
+            throw new SerializeException("Failed to deserialize json '%s'", e, json);
+        }
+    }
+
+    private static JavaType getCollectionType(Class<?> collectionClass,
+                                              Class<?>... elementClasses) {
+        return MAPPER.getTypeFactory().constructParametricType(collectionClass, elementClasses);
     }
 }

--- a/hugegraph-client/src/test/java/org/apache/hugegraph/unit/JsonUtilTest.java
+++ b/hugegraph-client/src/test/java/org/apache/hugegraph/unit/JsonUtilTest.java
@@ -1,0 +1,84 @@
+package org.apache.hugegraph.unit;
+
+import java.util.List;
+
+import org.apache.hugegraph.util.JsonUtil;
+import org.junit.Assert;
+import org.junit.Test;
+
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.ObjectMapper;
+
+public class JsonUtilTest {
+
+    private static Cat Tom = new Cat("Tom", 3);
+    private static Cat Butch = new Cat("Butch", 5);
+
+    private static String TOM_JSON = "{\"name\":\"Tom\",\"age\":3}";
+    private static String BUTCH_JSON = "{\"name\":\"Butch\",\"age\":5}";
+
+    private static String JSON_LIST = "[" + TOM_JSON + ", " + BUTCH_JSON + "]";
+
+    @Test
+    public void testToJson() {
+        Assert.assertEquals(TOM_JSON, JsonUtil.toJson(Tom));
+    }
+
+    @Test
+    public void testFromJson() {
+        Assert.assertEquals(Tom, JsonUtil.fromJson(TOM_JSON, Cat.class));
+    }
+
+    @Test
+    public void testConvertValue() throws JsonProcessingException {
+        ObjectMapper objectMapper = new ObjectMapper();
+        JsonNode jsonNode = objectMapper.readTree(TOM_JSON);
+        Assert.assertEquals(Tom, JsonUtil.convertValue(jsonNode, Cat.class));
+    }
+
+    @Test
+    public void testFromJson2List() {
+        List<Cat> cats = JsonUtil.fromJson2List(JSON_LIST, Cat.class);
+        Assert.assertEquals(2, cats.size());
+        Assert.assertEquals(Tom, cats.get(0));
+        Assert.assertEquals(Butch, cats.get(1));
+    }
+
+    static class Cat {
+
+        private String name;
+        private Integer age;
+
+        public Cat() {
+        }
+
+        public Cat(String name, Integer age) {
+            this.name = name;
+            this.age = age;
+        }
+
+        public String getName() {
+            return name;
+        }
+
+        public void setName(String name) {
+            this.name = name;
+        }
+
+        public Integer getAge() {
+            return age;
+        }
+
+        public void setAge(Integer age) {
+            this.age = age;
+        }
+
+        @Override
+        public boolean equals(Object obj) {
+            return obj instanceof Cat &&
+                   this.name.equals(((Cat) obj).getName()) &&
+                   this.age == ((Cat) obj).getAge();
+        }
+    }
+}

--- a/hugegraph-client/src/test/java/org/apache/hugegraph/unit/UnitTestSuite.java
+++ b/hugegraph-client/src/test/java/org/apache/hugegraph/unit/UnitTestSuite.java
@@ -30,7 +30,8 @@ import org.junit.runners.Suite;
         IndexLabelTest.class,
         CommonUtilTest.class,
         IdUtilTest.class,
-        SplicingIdGeneratorTest.class
+        SplicingIdGeneratorTest.class,
+        JsonUtilTest.class
 })
 public class UnitTestSuite {
 }


### PR DESCRIPTION
## Purpose of the PR

- close #576

## Main Changes
`org.apache.hugegraph.util.JsonUtil` supply method to parse json list.

## Verifying these changes
- [ ] Trivial rework / code cleanup without any test coverage. (No Need)
- [ ] Already covered by existing tests, such as *(please modify tests here)*.
- [X] Need tests and can be verified as follows:
    - `org.apache.hugegraph.unit.JsonUtilTest`

## Does this PR potentially affect the following parts?
- [X]  Nope
- [ ]  Dependencies (add/update license info) <!-- Don't forget to add/update the info in "LICENSE" & "NOTICE" files (both in root & dist module) -->
- [ ]  Modify configurations
- [ ]  The public API
- [ ]  Other affects (typed here)

## Documentation Status
- [ ]  `Doc - TODO` <!-- Your PR changes impact docs and you will update later -->
- [ ]  `Doc - Done` <!-- Related docs have been already added or updated -->
- [X]  `Doc - No Need` <!-- Your PR changes don't impact/need docs -->