### PR TITLE
fix(client): Add SameNeighborsBatchApiTest to test suite

### DIFF
--- a/hugegraph-client/src/test/java/org/apache/hugegraph/api/ApiTestSuite.java
+++ b/hugegraph-client/src/test/java/org/apache/hugegraph/api/ApiTestSuite.java
@@ -40,6 +40,7 @@ import org.apache.hugegraph.api.traverser.PathsApiTest;
 import org.apache.hugegraph.api.traverser.PersonalRankApiTest;
 import org.apache.hugegraph.api.traverser.RingsRaysApiTest;
 import org.apache.hugegraph.api.traverser.SameNeighborsApiTest;
+import org.apache.hugegraph.api.traverser.SameNeighborsBatchApiTest;
 import org.apache.hugegraph.api.traverser.ShortestPathApiTest;
 import org.apache.hugegraph.api.traverser.SingleSourceShortestPathApiTest;
 import org.apache.hugegraph.api.traverser.TemplatePathsApiTest;
@@ -74,6 +75,7 @@ import org.junit.runners.Suite;
         CountApiTest.class,
         RingsRaysApiTest.class,
         SameNeighborsApiTest.class,
+        SameNeighborsBatchApiTest.class,
         JaccardSimilarityApiTest.class,
         ShortestPathApiTest.class,
         AllShortestPathsApiTest.class,

--- a/hugegraph-client/src/test/java/org/apache/hugegraph/api/traverser/SameNeighborsBatchApiTest.java
+++ b/hugegraph-client/src/test/java/org/apache/hugegraph/api/traverser/SameNeighborsBatchApiTest.java
@@ -25,11 +25,9 @@ import org.apache.hugegraph.structure.traverser.SameNeighborsBatchRequest;
 import org.apache.hugegraph.testutil.Assert;
 import org.junit.BeforeClass;
 import org.junit.Test;
-import org.junit.Ignore;
 
 import com.google.common.collect.ImmutableList;
 
-@Ignore("Blocked by server: /traversers/sameneighborsbatch not implemented, see <https://github.com/apache/incubator-hugegraph/issues/2798>")
 public class SameNeighborsBatchApiTest extends TraverserApiTest {
 
     @BeforeClass

--- a/hugegraph-client/src/test/java/org/apache/hugegraph/api/traverser/SameNeighborsBatchApiTest.java
+++ b/hugegraph-client/src/test/java/org/apache/hugegraph/api/traverser/SameNeighborsBatchApiTest.java
@@ -25,9 +25,11 @@ import org.apache.hugegraph.structure.traverser.SameNeighborsBatchRequest;
 import org.apache.hugegraph.testutil.Assert;
 import org.junit.BeforeClass;
 import org.junit.Test;
+import org.junit.Ignore;
 
 import com.google.common.collect.ImmutableList;
 
+@Ignore("Blocked by server: /traversers/sameneighborsbatch not implemented, see <https://github.com/apache/incubator-hugegraph/issues/2798>")
 public class SameNeighborsBatchApiTest extends TraverserApiTest {
 
     @BeforeClass


### PR DESCRIPTION
Add SameNeighborsBatchApiTest to test suite (temporarily Ignore due to missing server API)

temporarily Ignore due to missing server API, related to server Issue#2798
https://github.com/apache/incubator-hugegraph/issues/2798

close #672