### PR TITLE
docs: add DeepWiki badge to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,6 +6,7 @@
 [![Build Status](https://github.com/apache/hugegraph-toolchain/actions/workflows/hubble-ci.yml/badge.svg)](https://github.com/apache/hugegraph-toolchain/actions/workflows/hubble-ci.yml)
 [![Build Status](https://github.com/apache/hugegraph-toolchain/actions/workflows/tools-ci.yml/badge.svg)](https://github.com/apache/hugegraph-toolchain/actions/workflows/tools-ci.yml)
 [![Maven Central](https://maven-badges.herokuapp.com/maven-central/org.apache.hugegraph/hugegraph-client/badge.svg)](https://mvnrepository.com/artifact/org.apache.hugegraph/hugegraph-client)
+[![Ask DeepWiki](https://deepwiki.com/badge.svg)](https://deepwiki.com/apache/hugegraph-toolchain)
 
 `hugegraph-toolchain` is the integration project contains a series of utilities for [HugeGraph](https://github.com/apache/hugegraph), 
 it includes 5+ main modules.


### PR DESCRIPTION
## Description

This PR adds a DeepWiki badge to the README file, enabling users to easily access interactive, AI-powered documentation for the HugeGraph Toolchain project.

## Changes
- Added DeepWiki badge in the badges section of README.md
- Badge links to https://deepwiki.com/apache/hugegraph-toolchain for up-to-date, interactive documentation

## Benefits
- Provides users with an alternative way to explore documentation through AI assistance
- Enables DeepWiki to automatically index and update project documentation
- Improves documentation accessibility and user experience

## Badge Preview
[![Ask DeepWiki](https://deepwiki.com/badge.svg)](https://deepwiki.com/apache/hugegraph-toolchain)