### PR TITLE
fix(client): Adapt client graphSpace method to 1.7.0 server

### DIFF
--- a/hugegraph-client/src/main/java/org/apache/hugegraph/api/space/GraphSpaceAPI.java
+++ b/hugegraph-client/src/main/java/org/apache/hugegraph/api/space/GraphSpaceAPI.java
@@ -28,9 +28,7 @@ import org.apache.hugegraph.structure.space.GraphSpace;
 import org.apache.hugegraph.util.JsonUtil;
 
 import java.util.ArrayList;
-import java.util.Collections;
 import java.util.HashMap;
-import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
 


### PR DESCRIPTION
## Purpose of the PR

-  The original `/profile` endpoint (used to fetch detailed configurations of all GraphSpaces in one call) has been removed in the latest 1.7.0 server, causing the `listProfile` method to fail. 
- 

## Main Changes

1. **Logic Refactoring**: Replaced the single REST call to `/profile` with a "List-then-Get" pattern (fetching the name list first, then retrieving details for each entry).
2. **Prefix Filtering**: Implemented in-memory filtering logic using `startsWith(prefix)` to maintain consistency with the legacy API behavior.

## Documentation Status

- [ ]  `Doc - TODO` 
- [ ]  `Doc - Done` 
- [x]  `Doc - No Need`