### PR TITLE
chore: update lombok version to 1.18.32 in pom.xml

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -129,7 +129,7 @@
         <zookeeper.version>3.6.2</zookeeper.version>
         <junit.version>4.12</junit.version>
         <mockito.version>2.25.1</mockito.version>
-        <lombok.version>1.18.8</lombok.version>
+        <lombok.version>1.18.32</lombok.version>
         <commons.io.version>2.8.0</commons.io.version>
         <commons.lang3.version>3.9</commons.lang3.version>
         <commons.compress.version>1.21</commons.compress.version>


### PR DESCRIPTION

![img_v3_02vs_b4072b3d-fc65-4e31-9e8a-b4782bbe345g](https://github.com/user-attachments/assets/2ff41625-4acc-4051-9c94-50a072135124)

[ERROR] Failed to execute goal org.apache.maven.plugins:maven-compiler-plugin:3.1:compile (default-compile) on project hugegraph-client: Fatal error compiling: java.lang.IllegalAccessError: class lombok.javac.apt.LombokProcessor (in unnamed module @0x20c71) cannot access class com.sun.tools.javac.processing.JavacProcessingEnvironment (in module jdk.compiler) because module jdk.compiler does not export com.sun.tools.javac.processing to unnamed module @0x20c71 -> [Help 1]
[ERROR] 
[ERROR] To see the full stack trace of the errors, re-run Maven with the -e switch.
[ERROR] Re-run Maven using the -X switch to enable full debug logging.
[ERROR] 
[ERROR] For more information about the errors and possible solutions, please read the following articles:
[ERROR] [Help 1] http://cwiki.apache.org/confluence/display/MAVEN/MojoExecutionException
[ERROR] 
[ERROR] After correcting the problems, you can resume the build with the command
[ERROR]   mvn <args> -rf :hugegraph-client

接下来是成功install后的

![img_v3_02vs_602a1fcf-dfe8-47e3-9ffa-6d5f789296ag](https://github.com/user-attachments/assets/8560bd17-bc5f-4d52-ae2b-7fb7837ba1a7)
