### PR TITLE
fix(loader): use HTTPS download URLs in travis scripts

### DIFF
--- a/hugegraph-loader/assembly/travis/install-hadoop.sh
+++ b/hugegraph-loader/assembly/travis/install-hadoop.sh
@@ -17,7 +17,7 @@
 #
 set -ev
 
-sudo wget http://archive.apache.org/dist/hadoop/common/hadoop-2.8.5/hadoop-2.8.5.tar.gz
+sudo wget https://archive.apache.org/dist/hadoop/common/hadoop-2.8.5/hadoop-2.8.5.tar.gz
 
 sudo tar -zxf hadoop-2.8.5.tar.gz -C /usr/local
 cd /usr/local

--- a/hugegraph-loader/assembly/travis/install-mysql.sh
+++ b/hugegraph-loader/assembly/travis/install-mysql.sh
@@ -32,7 +32,7 @@ docker run -p 3306:3306 --name "$1" -e MYSQL_ROOT_PASSWORD="$2" -d mysql:5.7
 
 
 # Old Version
-#MYSQL_DOWNLOAD_ADDRESS="http://dev.MySQL.com/get/Downloads"
+#MYSQL_DOWNLOAD_ADDRESS="https://dev.mysql.com/get/Downloads"
 #MYSQL_VERSION="MySQL-5.7"
 #MYSQL_PACKAGE="mysql-5.7.11-Linux-glibc2.5-x86_64"
 #MYSQL_TAR="${MYSQL_PACKAGE}.tar.gz"


### PR DESCRIPTION
## Purpose of the PR

- close https://github.com/apache/hugegraph/issues/2971

This fixes the similar HTTP download URL issue called out for the toolchain repository in `apache/hugegraph#2971`.

## Main Changes

- switch `hugegraph-loader/assembly/travis/install-hadoop.sh` to download Hadoop 2.8.5 from `https://archive.apache.org`
- update the retained legacy MySQL download comment in `hugegraph-loader/assembly/travis/install-mysql.sh` to its HTTPS form so the script no longer points to an insecure URL

## Verifying these changes

- [ ] Trivial rework / code cleanup without any test coverage. (No Need)
- [ ] Already covered by existing tests, such as *(please modify tests here)*.
- [x] Need tests and can be verified as follows:
    - `bash -n hugegraph-loader/assembly/travis/install-hadoop.sh hugegraph-loader/assembly/travis/install-mysql.sh`
    - `curl -I -L --max-time 20 https://archive.apache.org/dist/hadoop/common/hadoop-2.8.5/hadoop-2.8.5.tar.gz`

## Does this PR potentially affect the following parts?

- [x]  Nope
- [ ]  Dependencies (add/update license info)
- [ ]  Modify configurations
- [ ]  The public API
- [ ]  Other affects (typed here)

## Documentation Status

- [ ]  `Doc - TODO`
- [ ]  `Doc - Done`
- [x]  `Doc - No Need`
