### PR TITLE
fix(workflows): unify HugeGraph toolchain's CI

### DIFF
--- a/.github/workflows/client-ci.yml
+++ b/.github/workflows/client-ci.yml
@@ -5,7 +5,7 @@ on:
   push:
     branches:
       - master
-      - /^release-.*$/
+      - release-*
     paths:
       - hugegraph-client/**
       - hugegraph-dist/**
@@ -20,72 +20,22 @@ on:
 
 jobs:
   client-ci:
-    runs-on: ubuntu-latest
-    env:
-      USE_STAGE: 'true' # Whether to include the stage repository.
-      TRAVIS_DIR: hugegraph-client/assembly/travis
-      # TODO: replace it with the (latest - n) commit id (n >= 15)
-      # hugegraph commit date: 2025-11-4
-      COMMIT_ID: b7998c1
-    strategy:
-      fail-fast: false
-      matrix:
-        # released pd package is compiled in version 55.0, which requires java 11 to use
-        JAVA_VERSION: [ '11' ]
-
-    steps:
-      - name: Fetch code
-        uses: actions/checkout@v4
-        with:
-          fetch-depth: 2
-
-      # TODO: do we need it? (need test)
-      - name: Cache Maven packages
-        uses: actions/cache@v4
-        with:
-          path: ~/.m2/repository
-          key: ${{ runner.os }}-maven-${{ hashFiles('**/pom.xml') }}
-          restore-keys: ${{ runner.os }}-maven-
-
-      - name: Install JDK 11 for graph server
-        uses: actions/setup-java@v4
-        with:
-          java-version: '11'
-          distribution: 'zulu'
-          cache: 'maven'
-
-      - name: Prepare env and service
-        run: |
-          # TODO(@Thespica): test both servers of supporting gs and not supporting gs
-          #                  when the server supports gs
-          $TRAVIS_DIR/install-hugegraph-from-source.sh $COMMIT_ID
-
-      - name: Install Java ${{ matrix.JAVA_VERSION }} for client
-        uses: actions/setup-java@v4
-        with:
-          java-version: ${{ matrix.JAVA_VERSION }}
-          distribution: 'zulu'
-          cache: 'maven'
-
-      - name: Use staged maven repo
-        if: ${{ env.USE_STAGE == 'true' }}
-        run: |
-          cp $HOME/.m2/settings.xml /tmp/settings.xml
-          mv -vf .github/configs/settings.xml $HOME/.m2/settings.xml
-
-      - name: Compile
-        run: |
-          mvn -e compile -pl hugegraph-client -Dmaven.javadoc.skip=true -ntp
-
-      - name: Run test
-        run: |
-          cd hugegraph-client && ls *
-          mvn test -Dtest=UnitTestSuite -ntp
-          mvn test -Dtest=ApiTestSuite
-          mvn test -Dtest=FuncTestSuite
-
-      - name: Upload coverage to Codecov
-        uses: codecov/codecov-action@v3
-        with:
-          token: ${{ secrets.CODECOV_TOKEN }}
-          file: target/jacoco.xml
+    uses: hugegraph/actions/.github/workflows/_toolchain_java_ci_reusable.yml@master
+    with:
+      java_version: '11'
+      use_stage: true
+      settings_path: .github/configs/settings.xml
+      compile_command: |
+        mvn -e compile -pl hugegraph-client -Dmaven.javadoc.skip=true -ntp
+      prepare_command: |
+        TRAVIS_DIR=hugegraph-client/assembly/travis
+        # TODO(@Thespica): test both servers of supporting gs and not supporting gs
+        #                  when the server supports gs
+        "$TRAVIS_DIR"/install-hugegraph-from-source.sh b7998c1
+      test_command: |
+        cd hugegraph-client && ls *
+        mvn test -Dtest=UnitTestSuite -ntp
+        mvn test -Dtest=ApiTestSuite
+        mvn test -Dtest=FuncTestSuite
+      codecov_file: target/jacoco.xml
+    secrets: inherit

--- a/.github/workflows/client-go-ci.yml
+++ b/.github/workflows/client-go-ci.yml
@@ -4,7 +4,7 @@ on:
   push:
     branches:
       - master
-      - /^release-.*$/
+      - release-*
     paths:
       - hugegraph-client-go/**
       - hugegraph-dist/**
@@ -19,56 +19,20 @@ on:
 
 jobs:
   client-go-ci:
-    runs-on: ubuntu-latest
-    env:
-      USE_STAGE: 'true' # Whether to include the stage repository.
-      TRAVIS_DIR: hugegraph-client/assembly/travis
-      # TODO: replace it with the (latest - n) commit id (n >= 15)
-      # FIXME: hugegraph commit date: 2025-10-30
-      COMMIT_ID: 8c1ee71 # 5b3d295
-    strategy:
-      fail-fast: false
-      matrix:
-        JAVA_VERSION: ['11']
-
-    steps:
-      - name: Fetch Code
-        uses: actions/checkout@v4
-        with:
-          fetch-depth: 2
-
-      - name: Install JDK 11
-        uses: actions/setup-java@v3
-        with:
-          java-version: ${{ matrix.JAVA_VERSION }}
-          distribution: 'zulu'
-
-      - name: Cache Maven packages
-        uses: actions/cache@v3
-        with:
-          path: ~/.m2
-          key: ${{ runner.os }}-m2-${{ hashFiles('**/pom.xml') }}
-          restore-keys: ${{ runner.os }}-m2
-
-      - name: Use staged maven repo
-        if: ${{ env.USE_STAGE == 'true' }}
-        run: |
-          cp $HOME/.m2/settings.xml /tmp/settings.xml
-          mv -vf .github/configs/settings.xml $HOME/.m2/settings.xml
-
-      - name: Prepare env and service
-        run: |
-          $TRAVIS_DIR/install-hugegraph-from-source.sh $COMMIT_ID
-
-      - name: Init Go env
-        uses: actions/setup-go@v2.1.3
-        with: {go-version: '1.x'}
-
-      - name: Go test
-        run: |
-          go version  
-          sudo swapoff -a
-          sudo sysctl -w vm.swappiness=1
-          sudo sysctl -w fs.file-max=262144
-          sudo sysctl -w vm.max_map_count=262144
-          cd hugegraph-client-go && make test
+    uses: hugegraph/actions/.github/workflows/_toolchain_go_ci_reusable.yml@master
+    with:
+      java_version: '11'
+      go_version: '1.x'
+      use_stage: true
+      settings_path: .github/configs/settings.xml
+      prepare_command: |
+        TRAVIS_DIR=hugegraph-client/assembly/travis
+        "$TRAVIS_DIR"/install-hugegraph-from-source.sh 8c1ee71
+      test_command: |
+        go version
+        sudo swapoff -a
+        sudo sysctl -w vm.swappiness=1
+        sudo sysctl -w fs.file-max=262144
+        sudo sysctl -w vm.max_map_count=262144
+        cd hugegraph-client-go && make test
+    secrets: inherit

--- a/.github/workflows/hubble-ci.yml
+++ b/.github/workflows/hubble-ci.yml
@@ -5,7 +5,7 @@ on:
   push:
     branches:
       - master
-      - /^release-.*$/
+      - release-*
     paths:
       - hugegraph-hubble/**
       - hugegraph-dist/**
@@ -21,88 +21,34 @@ on:
       - .github/workflows/**
       - pom.xml
 
-env:
-  TRAVIS_DIR: hugegraph-hubble/hubble-dist/assembly/travis
-  # TODO: replace it with the (latest - n) commit id (n >= 15)
-  # FIXME: hugegraph commit date: 2025-10-30
-  COMMIT_ID: 8c1ee71 # 5b3d295
-
 jobs:
   hubble-ci:
-    runs-on: ubuntu-latest
-    env:
-      USE_STAGE: 'true' # Whether to include the stage repository.
-      STATIC_DIR: hugegraph-hubble/hubble-dist/assembly/static
-    strategy:
-      matrix:
-        JAVA_VERSION: ['11']
-        python-version: ["3.11"]
+    uses: hugegraph/actions/.github/workflows/_toolchain_java_ci_reusable.yml@master
+    with:
+      java_version: '11'
+      python_version: '3.11'
+      use_stage: true
+      settings_path: .github/configs/settings.xml
+      compile_command: |
+        mvn install -pl hugegraph-client,hugegraph-loader -am -Dmaven.javadoc.skip=true -DskipTests -ntp
+        cd hugegraph-hubble && ls *
+        mvn -e compile -Dmaven.javadoc.skip=true -ntp
+      prepare_command: |
+        TRAVIS_DIR=hugegraph-hubble/hubble-dist/assembly/travis
 
-    steps:
-      - name: Fetch Code
-        uses: actions/checkout@v4
-        with:
-          fetch-depth: 2
-
-      - name: Install JDK 11
-        uses: actions/setup-java@v3
-        with:
-          java-version: ${{ matrix.JAVA_VERSION }}
-          distribution: 'adopt'
-
-      - name: Set up Python ${{ matrix.python-version }}
-        uses: actions/setup-python@v5
-        with:
-          python-version: ${{ matrix.python-version }}
-          cache: 'pip'
-
-      # we also should cache python & yarn & downloads to avoid useless work
-      - name: Cache Maven packages
-        uses: actions/cache@v3
-        with:
-          path: ~/.m2/repository
-          key: ${{ runner.os }}-maven-${{ hashFiles('**/pom.xml') }}
-          restore-keys: |
-            ${{ runner.os }}-maven-
-
-      - name: use staged maven repo settings
-        if: ${{ env.USE_STAGE == 'true' }}
-        run: |
-          cp $HOME/.m2/settings.xml /tmp/settings.xml
-          mv -vf .github/configs/settings.xml $HOME/.m2/settings.xml
-
-      - name: Compile
-        run: |
-          mvn install -pl hugegraph-client,hugegraph-loader -am -Dmaven.javadoc.skip=true -DskipTests -ntp
-          cd hugegraph-hubble && ls *
-          mvn -e compile -Dmaven.javadoc.skip=true -ntp
-
-      - name: Prepare env and service
-        run: |
-          
-          python -m pip install -r ${TRAVIS_DIR}/requirements.txt
-          cd hugegraph-hubble
-          mvn package -Dmaven.test.skip=true
-          cd apache-hugegraph-hubble-*
-          cd bin
-          ./start-hubble.sh -d
-          ./stop-hubble.sh
-          cd ../../../
-          pwd
-          $TRAVIS_DIR/install-hugegraph.sh $COMMIT_ID
-
-      - name: Unit test
-        run: mvn test -P unit-test -pl hugegraph-hubble/hubble-be -ntp
-
-      - name: API test
-        env:
-          CI: false
-        run: |
-          cd hugegraph-hubble && ls
-          hubble-dist/assembly/travis/run-api-test.sh
-
-      - name: Upload coverage to Codecov
-        uses: codecov/codecov-action@v3
-        with:
-          token: ${{ secrets.CODECOV_TOKEN }}
-          file: target/site/jacoco/*.xml
+        python -m pip install -r "$TRAVIS_DIR"/requirements.txt
+        cd hugegraph-hubble
+        mvn package -Dmaven.test.skip=true
+        cd apache-hugegraph-hubble-*
+        cd bin
+        ./start-hubble.sh -d
+        ./stop-hubble.sh
+        cd ../../../
+        pwd
+        "$TRAVIS_DIR"/install-hugegraph.sh 8c1ee71
+      test_command: |
+        mvn test -P unit-test -pl hugegraph-hubble/hubble-be -ntp
+        cd hugegraph-hubble && ls
+        CI=false hubble-dist/assembly/travis/run-api-test.sh
+      codecov_file: target/site/jacoco/*.xml
+    secrets: inherit

--- a/.github/workflows/loader-ci.yml
+++ b/.github/workflows/loader-ci.yml
@@ -5,7 +5,7 @@ on:
   push:
     branches:
       - master
-      - /^release-.*$/
+      - release-*
     paths:
       - hugegraph-loader/**
       - hugegraph-dist/**
@@ -21,67 +21,24 @@ on:
 
 jobs:
   loader-ci:
-    runs-on: ubuntu-latest
-    env:
-      USE_STAGE: 'true' # Whether to include the stage repository.
-      TRAVIS_DIR: hugegraph-loader/assembly/travis
-      STATIC_DIR: hugegraph-loader/assembly/static
-      # TODO: replace it with the (latest - n) commit id (n >= 15)
-      # hugegraph commit date: 2025-10-30
-      COMMIT_ID: 5b3d295
-      DB_USER: root
-      DB_PASS: root
-      DB_DATABASE: load_test
-    strategy:
-      matrix:
-        JAVA_VERSION: ['11']
-
-    steps:
-      - name: Fetch Code
-        uses: actions/checkout@v4
-        with:
-          fetch-depth: 2
-
-      - name: Install JDK 11
-        uses: actions/setup-java@v4
-        with:
-          java-version: ${{ matrix.JAVA_VERSION }}
-          distribution: 'adopt'
-
-      - name: Cache Maven packages
-        uses: actions/cache@v4
-        with:
-          path: ~/.m2
-          key: ${{ runner.os }}-m2-${{ hashFiles('**/pom.xml') }}
-          restore-keys: ${{ runner.os }}-m2
-
-      - name: use staged maven repo settings
-        if: ${{ env.USE_STAGE == 'true' }}
-        run: |
-          cp $HOME/.m2/settings.xml /tmp/settings.xml
-          mv -vf .github/configs/settings.xml $HOME/.m2/settings.xml
-
-      - name: Compile
-        run: |
-          mvn install -pl hugegraph-client,hugegraph-loader -am -Dmaven.javadoc.skip=true -DskipTests -ntp
-
-      - name: Prepare env and service
-        run: |
-          $TRAVIS_DIR/install-hadoop.sh
-          $TRAVIS_DIR/install-mysql.sh ${{ env.DB_DATABASE }} ${{ env.DB_PASS }}
-          $TRAVIS_DIR/install-hugegraph-from-source.sh $COMMIT_ID
-
-      - name: Run test
-        run: |
-          cd hugegraph-loader && ls
-          mvn test -P unit -ntp
-          mvn test -P file
-          mvn test -P hdfs
-          mvn test -P jdbc
-          mvn test -P kafka
-
-      - name: Upload coverage to Codecov
-        uses: codecov/codecov-action@v4
-        with:
-          token: ${{ secrets.CODECOV_TOKEN }}
-          file: target/jacoco.xml
+    uses: hugegraph/actions/.github/workflows/_toolchain_java_ci_reusable.yml@master
+    with:
+      java_version: '11'
+      use_stage: true
+      settings_path: .github/configs/settings.xml
+      compile_command: |
+        mvn install -pl hugegraph-client,hugegraph-loader -am -Dmaven.javadoc.skip=true -DskipTests -ntp
+      prepare_command: |
+        TRAVIS_DIR=hugegraph-loader/assembly/travis
+        "$TRAVIS_DIR"/install-hadoop.sh
+        "$TRAVIS_DIR"/install-mysql.sh load_test root
+        "$TRAVIS_DIR"/install-hugegraph-from-source.sh 5b3d295
+      test_command: |
+        cd hugegraph-loader && ls
+        mvn test -P unit -ntp
+        mvn test -P file
+        mvn test -P hdfs
+        mvn test -P jdbc
+        mvn test -P kafka
+      codecov_file: target/jacoco.xml
+    secrets: inherit

--- a/.github/workflows/spark-connector-ci.yml
+++ b/.github/workflows/spark-connector-ci.yml
@@ -5,7 +5,7 @@ on:
   push:
     branches:
       - master
-      - /^release-.*$/
+      - release-*
     paths:
       - hugegraph-spark-connector/**
       - hugegraph-dist/**
@@ -21,50 +21,17 @@ on:
 
 jobs:
   spark-connector-ci:
-    runs-on: ubuntu-latest
-    env:
-      USE_STAGE: 'true' # Whether to include the stage repository.
-      TRAVIS_DIR: hugegraph-spark-connector/assembly/travis
-      # hugegraph commit date: 2025-10-30
-      COMMIT_ID: 5b3d295
-    strategy:
-      matrix:
-        JAVA_VERSION: [ '11' ]
-
-    steps:
-      - name: Fetch Code
-        uses: actions/checkout@v4
-        with:
-          fetch-depth: 2
-
-      - name: Install JDK 11
-        uses: actions/setup-java@v4
-        with:
-          java-version: '11'
-          distribution: 'adopt'
-
-      - name: Cache Maven packages
-        uses: actions/cache@v3
-        with:
-          path: ~/.m2
-          key: ${{ runner.os }}-m2-${{ hashFiles('**/pom.xml') }}
-          restore-keys: ${{ runner.os }}-m2
-
-      - name: use staged maven repo settings
-        if: ${{ env.USE_STAGE == 'true' }}
-        run: |
-          cp $HOME/.m2/settings.xml /tmp/settings.xml
-          mv -vf .github/configs/settings.xml $HOME/.m2/settings.xml
-
-      - name: Compile
-        run: |
-          mvn install -pl hugegraph-client,hugegraph-spark-connector -am -Dmaven.javadoc.skip=true -DskipTests -ntp
-
-      - name: Prepare env and service
-        run: |
-          $TRAVIS_DIR/install-hugegraph-from-source.sh $COMMIT_ID
-
-      - name: Run test
-        run: |
-          cd hugegraph-spark-connector && ls
-          mvn test
+    uses: hugegraph/actions/.github/workflows/_toolchain_java_ci_reusable.yml@master
+    with:
+      java_version: '11'
+      use_stage: true
+      settings_path: .github/configs/settings.xml
+      compile_command: |
+        mvn install -pl hugegraph-client,hugegraph-spark-connector -am -Dmaven.javadoc.skip=true -DskipTests -ntp
+      prepare_command: |
+        TRAVIS_DIR=hugegraph-spark-connector/assembly/travis
+        "$TRAVIS_DIR"/install-hugegraph-from-source.sh 5b3d295
+      test_command: |
+        cd hugegraph-spark-connector && ls
+        mvn test
+    secrets: inherit

--- a/.github/workflows/tools-ci.yml
+++ b/.github/workflows/tools-ci.yml
@@ -4,7 +4,7 @@ on:
   push:
     branches:
       - master
-      - /^release-.*$/
+      - release-*
     paths:
       - hugegraph-tools/**
       - hugegraph-dist/**
@@ -20,56 +20,17 @@ on:
 
 jobs:
   tools-ci:
-    runs-on: ubuntu-latest
-    env:
-      USE_STAGE: 'true' # Whether to include the stage repository.
-      TRAVIS_DIR: hugegraph-tools/assembly/travis
-      # TODO: could we use one param to unify it? or use a action template (could use one ci file)
-      # TODO: replace it with the (latest - n) commit id (n >= 15)
-      # hugegraph commit date: 2025-11-4
-      COMMIT_ID: b7998c1
-    strategy:
-      matrix:
-        JAVA_VERSION: [ '11' ]
-
-    steps:
-      - name: Fetch Code
-        uses: actions/checkout@v4
-        with:
-          fetch-depth: 2
-
-      - name: Install JDK 11
-        uses: actions/setup-java@v3
-        with:
-          java-version: ${{ matrix.JAVA_VERSION }}
-          distribution: 'adopt'
-      - name: Cache Maven packages
-        uses: actions/cache@v3
-        with:
-          path: ~/.m2
-          key: ${{ runner.os }}-m2-${{ hashFiles('**/pom.xml') }}
-          restore-keys: ${{ runner.os }}-m2
-
-      - name: use staged maven repo settings
-        if: ${{ env.USE_STAGE == 'true' }}
-        run: |
-          cp $HOME/.m2/settings.xml /tmp/settings.xml
-          mv -vf .github/configs/settings.xml $HOME/.m2/settings.xml
-
-      - name: Compile
-        run: |
-          mvn install -pl hugegraph-client,hugegraph-tools -am -Dmaven.javadoc.skip=true -DskipTests -ntp
-
-      - name: Prepare env and service
-        run: |
-          $TRAVIS_DIR/install-hugegraph-from-source.sh $COMMIT_ID
-
-      - name: Run test
-        run: |
-          mvn test -Dtest=FuncTestSuite -pl hugegraph-tools -ntp
-
-      - name: Upload coverage to Codecov
-        uses: codecov/codecov-action@v3
-        with:
-          token: ${{ secrets.CODECOV_TOKEN }}
-          file: target/jacoco.xml
+    uses: hugegraph/actions/.github/workflows/_toolchain_java_ci_reusable.yml@master
+    with:
+      java_version: '11'
+      use_stage: true
+      settings_path: .github/configs/settings.xml
+      compile_command: |
+        mvn install -pl hugegraph-client,hugegraph-tools -am -Dmaven.javadoc.skip=true -DskipTests -ntp
+      prepare_command: |
+        TRAVIS_DIR=hugegraph-tools/assembly/travis
+        "$TRAVIS_DIR"/install-hugegraph-from-source.sh b7998c1
+      test_command: |
+        mvn test -Dtest=FuncTestSuite -pl hugegraph-tools -ntp
+      codecov_file: target/jacoco.xml
+    secrets: inherit


### PR DESCRIPTION
<!-- 
  Thank you very much for contributing to Apache HugeGraph, we are happy that you want to help us improve it!

  Here are some tips for you:
    1. If this is your first time, please read the [contributing guidelines](https://github.com/apache/hugegraph/blob/master/CONTRIBUTING.md)

    2. If a PR fix/close an issue, type the message "close xxx" (xxx is the link of related 
issue) in the content, GitHub will auto link it (Required)

    3. Name the PR title in "Google Commit Format", start with "feat | fix | perf | refactor | doc | chore", 
      such like: "feat(core): support the PageRank algorithm" or "fix: wrong break in the compute loop" (module is optional)
      skip it if you are unsure about which is the best component.

    4. One PR address one issue, better not to mix up multiple issues.

    5. Put an `x` in the `[ ]` to mark the item as CHECKED. `[x]` (or click it directly after 
published)
-->

## Purpose of the PR

This PR migrates the current repository-local CI jobs in
`apache/hugegraph-toolchain` to shared reusable workflows hosted in
`hugegraph/actions`.

The goal is to reduce duplicated GitHub Actions logic across modules while
keeping each module's trigger policy, path filters, compile commands, prepare
commands, and test commands unchanged.

## Main Changes

- Replace the inline CI job definitions in these workflows with thin wrappers:
  - `client-ci.yml`
  - `client-go-ci.yml`
  - `loader-ci.yml`
  - `hubble-ci.yml`
  - `tools-ci.yml`
  - `spark-connector-ci.yml`
- Route Java-based modules to
  `hugegraph/actions/.github/workflows/_toolchain_java_ci_reusable.yml@master`.
- Route `hugegraph-client-go` to
  `hugegraph/actions/.github/workflows/_toolchain_go_ci_reusable.yml@master`.
- Keep the module-specific compile / prepare / test commands aligned with the
  previous workflows, including the existing HugeGraph commit ids and coverage
  upload behavior.
- Preserve caller-owned staged Maven settings by continuing to read
  `.github/configs/settings.xml` from the `hugegraph-toolchain` repository.
- Replace the invalid branch regex literal `/^release-.*$/` with the supported
  GitHub Actions glob `release-*`.

## Verifying these changes

- [ ] Trivial rework / code cleanup without any test coverage. (No Need)
- [ ] Already covered by existing tests, such as *(please modify tests here)*.
- [x] Need tests and can be verified as follows:
    - In a fork, temporarily point the wrappers to
      `peakxy/hugegraph-actions@<feature-branch>` for integration testing.
    - Manually trigger `client-ci` and confirm the reusable Java workflow keeps
      the original compile and test sequence.
    - Manually trigger `client-go-ci` and confirm the reusable Go workflow keeps
      the original HugeGraph environment preparation and `make test` flow.
    - Manually trigger `loader-ci` and `hubble-ci` to verify the more complex
      prepare steps still work with the reusable workflow inputs.
    - Push to a `release-*` branch and confirm the workflow trigger works with
      the updated branch filter.
    - Confirm `settings.xml` is still read from
      `.github/configs/settings.xml` in the caller repository.

## Does this PR potentially affect the following parts?

<!-- DO NOT REMOVE THIS SECTION. CHECK THE PROPER BOX ONLY. -->

- [ ]  Nope
- [ ]  Dependencies (add/update license info) <!-- Don't forget to add/update the info in "LICENSE" & "NOTICE" files (both in root & dist module) -->
- [x]  Modify configurations
- [ ]  The public API
- [x]  Other affects (GitHub Actions workflow structure for Toolchain CI)

## Documentation Status

<!-- DO NOT REMOVE THIS SECTION. CHECK THE PROPER BOX ONLY. -->

- [ ]  `Doc - TODO` <!-- Your PR changes impact docs and you will update later -->
- [ ]  `Doc - Done` <!-- Related docs have been already added or updated -->
- [x]  `Doc - No Need` <!-- Your PR changes don't impact/need docs -->
