### PR TITLE
chore(ci): replace hardcoded server commit with latest release

### DIFF
--- a/.github/actions/get-hugegraph-commit/action.yml
+++ b/.github/actions/get-hugegraph-commit/action.yml
@@ -16,15 +16,22 @@ runs:
         script: |
           const owner = 'apache';
           const repo = 'hugegraph';
-          const { data: release } = await github.rest.repos.getLatestRelease({ owner, repo });
-          const { data: ref } = await github.rest.git.getRef({
-            owner, repo, ref: `tags/${release.tag_name}`
-          });
-          let sha = ref.object.sha;
-          if (ref.object.type === 'tag') {
-            const { data: tag } = await github.rest.git.getTag({ owner, repo, tag_sha: sha });
-            sha = tag.object.sha;
+          try {
+            const { data: release } = await github.rest.repos.getLatestRelease({ owner, repo });
+            const tagName = release.tag_name;
+            const { data: ref } = await github.rest.git.getRef({
+              owner, repo, ref: `tags/${tagName}`
+            });
+            let sha = ref.object.sha;
+            if (ref.object.type === 'tag') {
+              const { data: tag } = await github.rest.git.getTag({ owner, repo, tag_sha: sha });
+              sha = tag.object.sha;
+            } else if (ref.object.type !== 'commit') {
+              throw new Error(`Unexpected ref type: ${ref.object.type}`);
+            }
+            core.exportVariable('COMMIT_ID', sha);
+            core.setOutput('commit_id', sha);
+            console.log(`Using HugeGraph release ${tagName} (${sha})`);
+          } catch (error) {
+            core.setFailed(`Failed to get HugeGraph commit: ${error.message}`);
           }
-          core.exportVariable('COMMIT_ID', sha);
-          core.setOutput('commit_id', sha);
-          console.log(`Using HugeGraph release ${release.tag_name} (${sha})`);

--- a/.github/actions/get-hugegraph-commit/action.yml
+++ b/.github/actions/get-hugegraph-commit/action.yml
@@ -1,0 +1,30 @@
+name: 'Get HugeGraph stable commit id'
+description: 'Fetch the latest HugeGraph release commit SHA and expose it as output and env variable'
+
+outputs:
+  commit_id:
+    description: 'The commit SHA of the latest HugeGraph release'
+    value: ${{ steps.get-commit.outputs.commit_id }}
+
+runs:
+  using: composite
+  steps:
+    - name: Get HugeGraph stable commit id
+      id: get-commit
+      uses: actions/github-script@v7
+      with:
+        script: |
+          const owner = 'apache';
+          const repo = 'hugegraph';
+          const { data: release } = await github.rest.repos.getLatestRelease({ owner, repo });
+          const { data: ref } = await github.rest.git.getRef({
+            owner, repo, ref: `tags/${release.tag_name}`
+          });
+          let sha = ref.object.sha;
+          if (ref.object.type === 'tag') {
+            const { data: tag } = await github.rest.git.getTag({ owner, repo, tag_sha: sha });
+            sha = tag.object.sha;
+          }
+          core.exportVariable('COMMIT_ID', sha);
+          core.setOutput('commit_id', sha);
+          console.log(`Using HugeGraph release ${release.tag_name} (${sha})`);

--- a/.github/actions/setup-hugegraph-server/action.yml
+++ b/.github/actions/setup-hugegraph-server/action.yml
@@ -1,0 +1,18 @@
+name: 'Setup HugeGraph Server'
+description: 'Prepare environment and install HugeGraph server from source'
+
+inputs:
+  travis-dir:
+    description: 'Path to the Travis assembly directory containing install scripts'
+    required: true
+  commit-id:
+    description: 'HugeGraph commit SHA to install'
+    required: true
+
+runs:
+  using: composite
+  steps:
+    - name: Prepare env and service
+      shell: bash
+      run: |
+        ${{ inputs.travis-dir }}/install-hugegraph-from-source.sh ${{ inputs.commit-id }}

--- a/.github/actions/setup-java-env/action.yml
+++ b/.github/actions/setup-java-env/action.yml
@@ -25,13 +25,6 @@ runs:
         distribution: ${{ inputs.distribution }}
         cache: 'maven'
 
-    - name: Cache Maven packages
-      uses: actions/cache@v4
-      with:
-        path: ~/.m2/repository
-        key: ${{ runner.os }}-maven-${{ hashFiles('**/pom.xml') }}
-        restore-keys: ${{ runner.os }}-maven-
-
     - name: Use staged maven repo settings
       if: ${{ inputs.use-stage == 'true' }}
       shell: bash

--- a/.github/actions/setup-java-env/action.yml
+++ b/.github/actions/setup-java-env/action.yml
@@ -1,0 +1,40 @@
+name: 'Setup Java and Maven Environment'
+description: 'Install JDK, cache Maven packages, and optionally apply staged Maven repository settings'
+
+inputs:
+  java-version:
+    description: 'Java version to install'
+    required: false
+    default: '11'
+  distribution:
+    description: 'JDK distribution'
+    required: false
+    default: 'zulu'
+  use-stage:
+    description: 'Whether to apply staged Maven repository settings'
+    required: false
+    default: 'true'
+
+runs:
+  using: composite
+  steps:
+    - name: Install JDK ${{ inputs.java-version }}
+      uses: actions/setup-java@v4
+      with:
+        java-version: ${{ inputs.java-version }}
+        distribution: ${{ inputs.distribution }}
+        cache: 'maven'
+
+    - name: Cache Maven packages
+      uses: actions/cache@v4
+      with:
+        path: ~/.m2/repository
+        key: ${{ runner.os }}-maven-${{ hashFiles('**/pom.xml') }}
+        restore-keys: ${{ runner.os }}-maven-
+
+    - name: Use staged maven repo settings
+      if: ${{ inputs.use-stage == 'true' }}
+      shell: bash
+      run: |
+        cp $HOME/.m2/settings.xml /tmp/settings.xml
+        mv -vf .github/configs/settings.xml $HOME/.m2/settings.xml

--- a/.github/actions/upload-coverage/action.yml
+++ b/.github/actions/upload-coverage/action.yml
@@ -1,0 +1,20 @@
+name: 'Upload Coverage to Codecov'
+description: 'Upload test coverage report to Codecov'
+
+inputs:
+  token:
+    description: 'Codecov upload token'
+    required: true
+  file:
+    description: 'Path to the coverage report file'
+    required: false
+    default: 'target/jacoco.xml'
+
+runs:
+  using: composite
+  steps:
+    - name: Upload coverage to Codecov
+      uses: codecov/codecov-action@v4
+      with:
+        token: ${{ inputs.token }}
+        file: ${{ inputs.file }}

--- a/.github/workflows/client-ci.yml
+++ b/.github/workflows/client-ci.yml
@@ -38,57 +38,20 @@ jobs:
 
       - name: Get HugeGraph stable commit id
         id: get-commit
-        uses: actions/github-script@v7
-        with:
-          script: |
-            const owner = 'apache';
-            const repo = 'hugegraph';
-            const { data: release } = await github.rest.repos.getLatestRelease({ owner, repo });
-            const { data: ref } = await github.rest.git.getRef({
-              owner, repo, ref: `tags/${release.tag_name}`
-            });
-            let sha = ref.object.sha;
-            if (ref.object.type === 'tag') {
-              const { data: tag } = await github.rest.git.getTag({ owner, repo, tag_sha: sha });
-              sha = tag.object.sha;
-            }
-            core.exportVariable('COMMIT_ID', sha);
-            core.setOutput('commit_id', sha);
-            console.log(`Using HugeGraph release ${release.tag_name} (${sha})`);
+        uses: ./.github/actions/get-hugegraph-commit
 
-      # TODO: do we need it? (need test)
-      - name: Cache Maven packages
-        uses: actions/cache@v4
-        with:
-          path: ~/.m2/repository
-          key: ${{ runner.os }}-maven-${{ hashFiles('**/pom.xml') }}
-          restore-keys: ${{ runner.os }}-maven-
-
-      - name: Install JDK 11 for graph server
-        uses: actions/setup-java@v4
-        with:
-          java-version: '11'
-          distribution: 'zulu'
-          cache: 'maven'
-
-      - name: Prepare env and service
-        run: |
-          # TODO(@Thespica): test both servers of supporting gs and not supporting gs
-          #                  when the server supports gs
-          $TRAVIS_DIR/install-hugegraph-from-source.sh $COMMIT_ID
-
-      - name: Install Java ${{ matrix.JAVA_VERSION }} for client
-        uses: actions/setup-java@v4
+      - name: Setup Java environment
+        uses: ./.github/actions/setup-java-env
         with:
           java-version: ${{ matrix.JAVA_VERSION }}
           distribution: 'zulu'
-          cache: 'maven'
+          use-stage: ${{ env.USE_STAGE }}
 
-      - name: Use staged maven repo
-        if: ${{ env.USE_STAGE == 'true' }}
-        run: |
-          cp $HOME/.m2/settings.xml /tmp/settings.xml
-          mv -vf .github/configs/settings.xml $HOME/.m2/settings.xml
+      - name: Setup HugeGraph server
+        uses: ./.github/actions/setup-hugegraph-server
+        with:
+          travis-dir: ${{ env.TRAVIS_DIR }}
+          commit-id: ${{ steps.get-commit.outputs.commit_id }}
 
       - name: Compile
         run: |
@@ -102,7 +65,7 @@ jobs:
           mvn test -Dtest=FuncTestSuite
 
       - name: Upload coverage to Codecov
-        uses: codecov/codecov-action@v3
+        uses: ./.github/actions/upload-coverage
         with:
           token: ${{ secrets.CODECOV_TOKEN }}
           file: target/jacoco.xml

--- a/.github/workflows/client-ci.yml
+++ b/.github/workflows/client-ci.yml
@@ -52,7 +52,6 @@ jobs:
               const { data: tag } = await github.rest.git.getTag({ owner, repo, tag_sha: sha });
               sha = tag.object.sha;
             }
-            sha = sha.substring(0, 7);
             core.exportVariable('COMMIT_ID', sha);
             core.setOutput('commit_id', sha);
             console.log(`Using HugeGraph release ${release.tag_name} (${sha})`);

--- a/.github/workflows/client-ci.yml
+++ b/.github/workflows/client-ci.yml
@@ -41,19 +41,21 @@ jobs:
         uses: actions/github-script@v7
         with:
           script: |
-            const offset = 15;
-            const { data: commits } = await github.rest.repos.listCommits({
-              owner: 'apache',
-              repo: 'hugegraph',
-              per_page: offset + 1
+            const owner = 'apache';
+            const repo = 'hugegraph';
+            const { data: release } = await github.rest.repos.getLatestRelease({ owner, repo });
+            const { data: ref } = await github.rest.git.getRef({
+              owner, repo, ref: `tags/${release.tag_name}`
             });
-            if (commits.length <= offset) {
-              core.setFailed(`Not enough commits. Found ${commits.length}, needed ${offset + 1}`);
-              return;
+            let sha = ref.object.sha;
+            if (ref.object.type === 'tag') {
+              const { data: tag } = await github.rest.git.getTag({ owner, repo, tag_sha: sha });
+              sha = tag.object.sha;
             }
-            const sha = commits[offset].sha.substring(0, 7);
+            sha = sha.substring(0, 7);
             core.exportVariable('COMMIT_ID', sha);
-            console.log(`Using HugeGraph commit id: ${sha}`);
+            core.setOutput('commit_id', sha);
+            console.log(`Using HugeGraph release ${release.tag_name} (${sha})`);
 
       # TODO: do we need it? (need test)
       - name: Cache Maven packages

--- a/.github/workflows/client-ci.yml
+++ b/.github/workflows/client-ci.yml
@@ -24,9 +24,6 @@ jobs:
     env:
       USE_STAGE: 'true' # Whether to include the stage repository.
       TRAVIS_DIR: hugegraph-client/assembly/travis
-      # TODO: replace it with the (latest - n) commit id (n >= 15)
-      # hugegraph commit date: 2025-11-4
-      COMMIT_ID: b7998c1
     strategy:
       fail-fast: false
       matrix:
@@ -38,6 +35,25 @@ jobs:
         uses: actions/checkout@v4
         with:
           fetch-depth: 2
+
+      - name: Get HugeGraph stable commit id
+        id: get-commit
+        uses: actions/github-script@v7
+        with:
+          script: |
+            const offset = 15;
+            const { data: commits } = await github.rest.repos.listCommits({
+              owner: 'apache',
+              repo: 'hugegraph',
+              per_page: offset + 1
+            });
+            if (commits.length <= offset) {
+              core.setFailed(`Not enough commits. Found ${commits.length}, needed ${offset + 1}`);
+              return;
+            }
+            const sha = commits[offset].sha.substring(0, 7);
+            core.exportVariable('COMMIT_ID', sha);
+            console.log(`Using HugeGraph commit id: ${sha}`);
 
       # TODO: do we need it? (need test)
       - name: Cache Maven packages

--- a/.github/workflows/client-go-ci.yml
+++ b/.github/workflows/client-go-ci.yml
@@ -23,9 +23,6 @@ jobs:
     env:
       USE_STAGE: 'true' # Whether to include the stage repository.
       TRAVIS_DIR: hugegraph-client/assembly/travis
-      # TODO: replace it with the (latest - n) commit id (n >= 15)
-      # FIXME: hugegraph commit date: 2025-10-30
-      COMMIT_ID: 8c1ee71 # 5b3d295
     strategy:
       fail-fast: false
       matrix:
@@ -36,6 +33,25 @@ jobs:
         uses: actions/checkout@v4
         with:
           fetch-depth: 2
+
+      - name: Get HugeGraph stable commit id
+        uses: actions/github-script@v7
+        with:
+          script: |
+            const owner = 'apache';
+            const repo = 'hugegraph';
+            const { data: release } = await github.rest.repos.getLatestRelease({ owner, repo });
+            const { data: ref } = await github.rest.git.getRef({
+              owner, repo, ref: `tags/${release.tag_name}`
+            });
+            let sha = ref.object.sha;
+            if (ref.object.type === 'tag') {
+              const { data: tag } = await github.rest.git.getTag({ owner, repo, tag_sha: sha });
+              sha = tag.object.sha;
+            }
+            sha = sha.substring(0, 7);
+            core.exportVariable('COMMIT_ID', sha);
+            console.log(`Using HugeGraph release ${release.tag_name} (${sha})`);
 
       - name: Install JDK 11
         uses: actions/setup-java@v3

--- a/.github/workflows/client-go-ci.yml
+++ b/.github/workflows/client-go-ci.yml
@@ -49,7 +49,6 @@ jobs:
               const { data: tag } = await github.rest.git.getTag({ owner, repo, tag_sha: sha });
               sha = tag.object.sha;
             }
-            sha = sha.substring(0, 7);
             core.exportVariable('COMMIT_ID', sha);
             console.log(`Using HugeGraph release ${release.tag_name} (${sha})`);
 

--- a/.github/workflows/client-go-ci.yml
+++ b/.github/workflows/client-go-ci.yml
@@ -23,6 +23,9 @@ jobs:
     env:
       USE_STAGE: 'true' # Whether to include the stage repository.
       TRAVIS_DIR: hugegraph-client/assembly/travis
+      # TODO: replace it with the (latest - n) commit id (n >= 15)
+      # FIXME: hugegraph commit date: 2025-10-30
+      COMMIT_ID: 8c1ee71 # 5b3d295
     strategy:
       fail-fast: false
       matrix:
@@ -33,27 +36,6 @@ jobs:
         uses: actions/checkout@v4
         with:
           fetch-depth: 2
-
-      - name: Get HugeGraph stable commit id
-        id: get-commit
-        uses: actions/github-script@v7
-        with:
-          script: |
-            const owner = 'apache';
-            const repo = 'hugegraph';
-            const { data: release } = await github.rest.repos.getLatestRelease({ owner, repo });
-            const { data: ref } = await github.rest.git.getRef({
-              owner, repo, ref: `tags/${release.tag_name}`
-            });
-            let sha = ref.object.sha;
-            if (ref.object.type === 'tag') {
-              const { data: tag } = await github.rest.git.getTag({ owner, repo, tag_sha: sha });
-              sha = tag.object.sha;
-            }
-            sha = sha.substring(0, 7);
-            core.exportVariable('COMMIT_ID', sha);
-            core.setOutput('commit_id', sha);
-            console.log(`Using HugeGraph release ${release.tag_name} (${sha})`);
 
       - name: Install JDK 11
         uses: actions/setup-java@v3

--- a/.github/workflows/client-go-ci.yml
+++ b/.github/workflows/client-go-ci.yml
@@ -23,9 +23,6 @@ jobs:
     env:
       USE_STAGE: 'true' # Whether to include the stage repository.
       TRAVIS_DIR: hugegraph-client/assembly/travis
-      # TODO: replace it with the (latest - n) commit id (n >= 15)
-      # FIXME: hugegraph commit date: 2025-10-30
-      COMMIT_ID: 8c1ee71 # 5b3d295
     strategy:
       fail-fast: false
       matrix:
@@ -36,6 +33,25 @@ jobs:
         uses: actions/checkout@v4
         with:
           fetch-depth: 2
+
+      - name: Get HugeGraph stable commit id
+        id: get-commit
+        uses: actions/github-script@v7
+        with:
+          script: |
+            const offset = 15;
+            const { data: commits } = await github.rest.repos.listCommits({
+              owner: 'apache',
+              repo: 'hugegraph',
+              per_page: offset + 1
+            });
+            if (commits.length <= offset) {
+              core.setFailed(`Not enough commits. Found ${commits.length}, needed ${offset + 1}`);
+              return;
+            }
+            const sha = commits[offset].sha.substring(0, 7);
+            core.exportVariable('COMMIT_ID', sha);
+            console.log(`Using HugeGraph commit id: ${sha}`);
 
       - name: Install JDK 11
         uses: actions/setup-java@v3

--- a/.github/workflows/client-go-ci.yml
+++ b/.github/workflows/client-go-ci.yml
@@ -39,19 +39,21 @@ jobs:
         uses: actions/github-script@v7
         with:
           script: |
-            const offset = 15;
-            const { data: commits } = await github.rest.repos.listCommits({
-              owner: 'apache',
-              repo: 'hugegraph',
-              per_page: offset + 1
+            const owner = 'apache';
+            const repo = 'hugegraph';
+            const { data: release } = await github.rest.repos.getLatestRelease({ owner, repo });
+            const { data: ref } = await github.rest.git.getRef({
+              owner, repo, ref: `tags/${release.tag_name}`
             });
-            if (commits.length <= offset) {
-              core.setFailed(`Not enough commits. Found ${commits.length}, needed ${offset + 1}`);
-              return;
+            let sha = ref.object.sha;
+            if (ref.object.type === 'tag') {
+              const { data: tag } = await github.rest.git.getTag({ owner, repo, tag_sha: sha });
+              sha = tag.object.sha;
             }
-            const sha = commits[offset].sha.substring(0, 7);
+            sha = sha.substring(0, 7);
             core.exportVariable('COMMIT_ID', sha);
-            console.log(`Using HugeGraph commit id: ${sha}`);
+            core.setOutput('commit_id', sha);
+            console.log(`Using HugeGraph release ${release.tag_name} (${sha})`);
 
       - name: Install JDK 11
         uses: actions/setup-java@v3

--- a/.github/workflows/client-go-ci.yml
+++ b/.github/workflows/client-go-ci.yml
@@ -35,53 +35,30 @@ jobs:
           fetch-depth: 2
 
       - name: Get HugeGraph stable commit id
-        uses: actions/github-script@v7
-        with:
-          script: |
-            const owner = 'apache';
-            const repo = 'hugegraph';
-            const { data: release } = await github.rest.repos.getLatestRelease({ owner, repo });
-            const { data: ref } = await github.rest.git.getRef({
-              owner, repo, ref: `tags/${release.tag_name}`
-            });
-            let sha = ref.object.sha;
-            if (ref.object.type === 'tag') {
-              const { data: tag } = await github.rest.git.getTag({ owner, repo, tag_sha: sha });
-              sha = tag.object.sha;
-            }
-            core.exportVariable('COMMIT_ID', sha);
-            console.log(`Using HugeGraph release ${release.tag_name} (${sha})`);
+        id: get-commit
+        uses: ./.github/actions/get-hugegraph-commit
 
-      - name: Install JDK 11
-        uses: actions/setup-java@v3
+      - name: Setup Java environment
+        uses: ./.github/actions/setup-java-env
         with:
           java-version: ${{ matrix.JAVA_VERSION }}
           distribution: 'zulu'
+          use-stage: ${{ env.USE_STAGE }}
 
-      - name: Cache Maven packages
-        uses: actions/cache@v3
+      - name: Setup HugeGraph server
+        uses: ./.github/actions/setup-hugegraph-server
         with:
-          path: ~/.m2
-          key: ${{ runner.os }}-m2-${{ hashFiles('**/pom.xml') }}
-          restore-keys: ${{ runner.os }}-m2
-
-      - name: Use staged maven repo
-        if: ${{ env.USE_STAGE == 'true' }}
-        run: |
-          cp $HOME/.m2/settings.xml /tmp/settings.xml
-          mv -vf .github/configs/settings.xml $HOME/.m2/settings.xml
-
-      - name: Prepare env and service
-        run: |
-          $TRAVIS_DIR/install-hugegraph-from-source.sh $COMMIT_ID
+          travis-dir: ${{ env.TRAVIS_DIR }}
+          commit-id: ${{ steps.get-commit.outputs.commit_id }}
 
       - name: Init Go env
-        uses: actions/setup-go@v2.1.3
-        with: {go-version: '1.x'}
+        uses: actions/setup-go@v5
+        with:
+          go-version: '1.x'
 
       - name: Go test
         run: |
-          go version  
+          go version
           sudo swapoff -a
           sudo sysctl -w vm.swappiness=1
           sudo sysctl -w fs.file-max=262144

--- a/.github/workflows/hubble-ci.yml
+++ b/.github/workflows/hubble-ci.yml
@@ -46,19 +46,21 @@ jobs:
         uses: actions/github-script@v7
         with:
           script: |
-            const offset = 15;
-            const { data: commits } = await github.rest.repos.listCommits({
-              owner: 'apache',
-              repo: 'hugegraph',
-              per_page: offset + 1
+            const owner = 'apache';
+            const repo = 'hugegraph';
+            const { data: release } = await github.rest.repos.getLatestRelease({ owner, repo });
+            const { data: ref } = await github.rest.git.getRef({
+              owner, repo, ref: `tags/${release.tag_name}`
             });
-            if (commits.length <= offset) {
-              core.setFailed(`Not enough commits. Found ${commits.length}, needed ${offset + 1}`);
-              return;
+            let sha = ref.object.sha;
+            if (ref.object.type === 'tag') {
+              const { data: tag } = await github.rest.git.getTag({ owner, repo, tag_sha: sha });
+              sha = tag.object.sha;
             }
-            const sha = commits[offset].sha.substring(0, 7);
+            sha = sha.substring(0, 7);
             core.exportVariable('COMMIT_ID', sha);
-            console.log(`Using HugeGraph commit id: ${sha}`);
+            core.setOutput('commit_id', sha);
+            console.log(`Using HugeGraph release ${release.tag_name} (${sha})`);
 
       - name: Install JDK 11
         uses: actions/setup-java@v3

--- a/.github/workflows/hubble-ci.yml
+++ b/.github/workflows/hubble-ci.yml
@@ -23,9 +23,6 @@ on:
 
 env:
   TRAVIS_DIR: hugegraph-hubble/hubble-dist/assembly/travis
-  # TODO: replace it with the (latest - n) commit id (n >= 15)
-  # FIXME: hugegraph commit date: 2025-10-30
-  COMMIT_ID: 8c1ee71 # 5b3d295
 
 jobs:
   hubble-ci:
@@ -43,6 +40,25 @@ jobs:
         uses: actions/checkout@v4
         with:
           fetch-depth: 2
+
+      - name: Get HugeGraph stable commit id
+        id: get-commit
+        uses: actions/github-script@v7
+        with:
+          script: |
+            const offset = 15;
+            const { data: commits } = await github.rest.repos.listCommits({
+              owner: 'apache',
+              repo: 'hugegraph',
+              per_page: offset + 1
+            });
+            if (commits.length <= offset) {
+              core.setFailed(`Not enough commits. Found ${commits.length}, needed ${offset + 1}`);
+              return;
+            }
+            const sha = commits[offset].sha.substring(0, 7);
+            core.exportVariable('COMMIT_ID', sha);
+            console.log(`Using HugeGraph commit id: ${sha}`);
 
       - name: Install JDK 11
         uses: actions/setup-java@v3

--- a/.github/workflows/hubble-ci.yml
+++ b/.github/workflows/hubble-ci.yml
@@ -43,50 +43,20 @@ jobs:
 
       - name: Get HugeGraph stable commit id
         id: get-commit
-        uses: actions/github-script@v7
-        with:
-          script: |
-            const owner = 'apache';
-            const repo = 'hugegraph';
-            const { data: release } = await github.rest.repos.getLatestRelease({ owner, repo });
-            const { data: ref } = await github.rest.git.getRef({
-              owner, repo, ref: `tags/${release.tag_name}`
-            });
-            let sha = ref.object.sha;
-            if (ref.object.type === 'tag') {
-              const { data: tag } = await github.rest.git.getTag({ owner, repo, tag_sha: sha });
-              sha = tag.object.sha;
-            }
-            core.exportVariable('COMMIT_ID', sha);
-            core.setOutput('commit_id', sha);
-            console.log(`Using HugeGraph release ${release.tag_name} (${sha})`);
+        uses: ./.github/actions/get-hugegraph-commit
 
-      - name: Install JDK 11
-        uses: actions/setup-java@v3
+      - name: Setup Java environment
+        uses: ./.github/actions/setup-java-env
         with:
           java-version: ${{ matrix.JAVA_VERSION }}
           distribution: 'adopt'
+          use-stage: ${{ env.USE_STAGE }}
 
       - name: Set up Python ${{ matrix.python-version }}
         uses: actions/setup-python@v5
         with:
           python-version: ${{ matrix.python-version }}
           cache: 'pip'
-
-      # we also should cache python & yarn & downloads to avoid useless work
-      - name: Cache Maven packages
-        uses: actions/cache@v3
-        with:
-          path: ~/.m2/repository
-          key: ${{ runner.os }}-maven-${{ hashFiles('**/pom.xml') }}
-          restore-keys: |
-            ${{ runner.os }}-maven-
-
-      - name: use staged maven repo settings
-        if: ${{ env.USE_STAGE == 'true' }}
-        run: |
-          cp $HOME/.m2/settings.xml /tmp/settings.xml
-          mv -vf .github/configs/settings.xml $HOME/.m2/settings.xml
 
       - name: Compile
         run: |
@@ -96,7 +66,6 @@ jobs:
 
       - name: Prepare env and service
         run: |
-          
           python -m pip install -r ${TRAVIS_DIR}/requirements.txt
           cd hugegraph-hubble
           mvn package -Dmaven.test.skip=true
@@ -119,7 +88,7 @@ jobs:
           hubble-dist/assembly/travis/run-api-test.sh
 
       - name: Upload coverage to Codecov
-        uses: codecov/codecov-action@v3
+        uses: ./.github/actions/upload-coverage
         with:
           token: ${{ secrets.CODECOV_TOKEN }}
           file: target/site/jacoco/*.xml

--- a/.github/workflows/hubble-ci.yml
+++ b/.github/workflows/hubble-ci.yml
@@ -57,7 +57,6 @@ jobs:
               const { data: tag } = await github.rest.git.getTag({ owner, repo, tag_sha: sha });
               sha = tag.object.sha;
             }
-            sha = sha.substring(0, 7);
             core.exportVariable('COMMIT_ID', sha);
             core.setOutput('commit_id', sha);
             console.log(`Using HugeGraph release ${release.tag_name} (${sha})`);

--- a/.github/workflows/hubble-ci.yml
+++ b/.github/workflows/hubble-ci.yml
@@ -65,6 +65,8 @@ jobs:
           mvn -e compile -Dmaven.javadoc.skip=true -ntp
 
       - name: Prepare env and service
+        env:
+          COMMIT_ID: ${{ steps.get-commit.outputs.commit_id }}
         run: |
           python -m pip install -r ${TRAVIS_DIR}/requirements.txt
           cd hugegraph-hubble

--- a/.github/workflows/loader-ci.yml
+++ b/.github/workflows/loader-ci.yml
@@ -26,9 +26,6 @@ jobs:
       USE_STAGE: 'true' # Whether to include the stage repository.
       TRAVIS_DIR: hugegraph-loader/assembly/travis
       STATIC_DIR: hugegraph-loader/assembly/static
-      # TODO: replace it with the (latest - n) commit id (n >= 15)
-      # hugegraph commit date: 2025-10-30
-      COMMIT_ID: 5b3d295
       DB_USER: root
       DB_PASS: root
       DB_DATABASE: load_test
@@ -49,6 +46,25 @@ jobs:
         uses: actions/checkout@v4
         with:
           fetch-depth: 2
+
+      - name: Get HugeGraph stable commit id
+        id: get-commit
+        uses: actions/github-script@v7
+        with:
+          script: |
+            const offset = 15;
+            const { data: commits } = await github.rest.repos.listCommits({
+              owner: 'apache',
+              repo: 'hugegraph',
+              per_page: offset + 1
+            });
+            if (commits.length <= offset) {
+              core.setFailed(`Not enough commits. Found ${commits.length}, needed ${offset + 1}`);
+              return;
+            }
+            const sha = commits[offset].sha.substring(0, 7);
+            core.exportVariable('COMMIT_ID', sha);
+            console.log(`Using HugeGraph commit id: ${sha}`);
 
       - name: Install JDK 11
         uses: actions/setup-java@v4

--- a/.github/workflows/loader-ci.yml
+++ b/.github/workflows/loader-ci.yml
@@ -49,36 +49,14 @@ jobs:
 
       - name: Get HugeGraph stable commit id
         id: get-commit
-        uses: actions/github-script@v7
-        with:
-          script: |
-            const owner = 'apache';
-            const repo = 'hugegraph';
-            const { data: release } = await github.rest.repos.getLatestRelease({ owner, repo });
-            const { data: ref } = await github.rest.git.getRef({
-              owner, repo, ref: `tags/${release.tag_name}`
-            });
-            let sha = ref.object.sha;
-            if (ref.object.type === 'tag') {
-              const { data: tag } = await github.rest.git.getTag({ owner, repo, tag_sha: sha });
-              sha = tag.object.sha;
-            }
-            core.exportVariable('COMMIT_ID', sha);
-            core.setOutput('commit_id', sha);
-            console.log(`Using HugeGraph release ${release.tag_name} (${sha})`);
+        uses: ./.github/actions/get-hugegraph-commit
 
-      - name: Install JDK 11
-        uses: actions/setup-java@v4
+      - name: Setup Java environment
+        uses: ./.github/actions/setup-java-env
         with:
           java-version: ${{ matrix.JAVA_VERSION }}
           distribution: 'adopt'
-
-      - name: Cache Maven packages
-        uses: actions/cache@v4
-        with:
-          path: ~/.m2
-          key: ${{ runner.os }}-m2-${{ hashFiles('**/pom.xml') }}
-          restore-keys: ${{ runner.os }}-m2
+          use-stage: ${{ env.USE_STAGE }}
 
       - name: Cache Hadoop
         uses: actions/cache@v4
@@ -91,12 +69,6 @@ jobs:
         with:
           path: ~/hugegraph-cache-${{ steps.get-commit.outputs.commit_id }}
           key: ${{ runner.os }}-hugegraph-server-${{ steps.get-commit.outputs.commit_id }}
-
-      - name: use staged maven repo settings
-        if: ${{ env.USE_STAGE == 'true' }}
-        run: |
-          cp $HOME/.m2/settings.xml /tmp/settings.xml
-          mv -vf .github/configs/settings.xml $HOME/.m2/settings.xml
 
       - name: Compile
         run: |
@@ -117,7 +89,7 @@ jobs:
           mvn test -P kafka
 
       - name: Upload coverage to Codecov
-        uses: codecov/codecov-action@v4
+        uses: ./.github/actions/upload-coverage
         with:
           token: ${{ secrets.CODECOV_TOKEN }}
           file: target/jacoco.xml

--- a/.github/workflows/loader-ci.yml
+++ b/.github/workflows/loader-ci.yml
@@ -75,6 +75,8 @@ jobs:
           mvn install -pl hugegraph-client,hugegraph-loader -am -Dmaven.javadoc.skip=true -DskipTests -ntp
 
       - name: Prepare env and service
+        env:
+          COMMIT_ID: ${{ steps.get-commit.outputs.commit_id }}
         run: |
           $TRAVIS_DIR/install-hadoop.sh
           $TRAVIS_DIR/install-hugegraph-from-source.sh $COMMIT_ID

--- a/.github/workflows/loader-ci.yml
+++ b/.github/workflows/loader-ci.yml
@@ -64,6 +64,7 @@ jobs:
             }
             const sha = commits[offset].sha.substring(0, 7);
             core.exportVariable('COMMIT_ID', sha);
+            core.setOutput('commit_id', sha);
             console.log(`Using HugeGraph commit id: ${sha}`);
 
       - name: Install JDK 11
@@ -88,8 +89,8 @@ jobs:
       - name: Cache HugeGraph Server
         uses: actions/cache@v4
         with:
-          path: ~/hugegraph-cache-${{ env.COMMIT_ID }}
-          key: ${{ runner.os }}-hugegraph-server-${{ env.COMMIT_ID }}
+          path: ~/hugegraph-cache-${{ steps.get-commit.outputs.commit_id }}
+          key: ${{ runner.os }}-hugegraph-server-${{ steps.get-commit.outputs.commit_id }}
 
       - name: use staged maven repo settings
         if: ${{ env.USE_STAGE == 'true' }}

--- a/.github/workflows/loader-ci.yml
+++ b/.github/workflows/loader-ci.yml
@@ -52,20 +52,21 @@ jobs:
         uses: actions/github-script@v7
         with:
           script: |
-            const offset = 15;
-            const { data: commits } = await github.rest.repos.listCommits({
-              owner: 'apache',
-              repo: 'hugegraph',
-              per_page: offset + 1
+            const owner = 'apache';
+            const repo = 'hugegraph';
+            const { data: release } = await github.rest.repos.getLatestRelease({ owner, repo });
+            const { data: ref } = await github.rest.git.getRef({
+              owner, repo, ref: `tags/${release.tag_name}`
             });
-            if (commits.length <= offset) {
-              core.setFailed(`Not enough commits. Found ${commits.length}, needed ${offset + 1}`);
-              return;
+            let sha = ref.object.sha;
+            if (ref.object.type === 'tag') {
+              const { data: tag } = await github.rest.git.getTag({ owner, repo, tag_sha: sha });
+              sha = tag.object.sha;
             }
-            const sha = commits[offset].sha.substring(0, 7);
+            sha = sha.substring(0, 7);
             core.exportVariable('COMMIT_ID', sha);
             core.setOutput('commit_id', sha);
-            console.log(`Using HugeGraph commit id: ${sha}`);
+            console.log(`Using HugeGraph release ${release.tag_name} (${sha})`);
 
       - name: Install JDK 11
         uses: actions/setup-java@v4

--- a/.github/workflows/loader-ci.yml
+++ b/.github/workflows/loader-ci.yml
@@ -63,7 +63,6 @@ jobs:
               const { data: tag } = await github.rest.git.getTag({ owner, repo, tag_sha: sha });
               sha = tag.object.sha;
             }
-            sha = sha.substring(0, 7);
             core.exportVariable('COMMIT_ID', sha);
             core.setOutput('commit_id', sha);
             console.log(`Using HugeGraph release ${release.tag_name} (${sha})`);

--- a/.github/workflows/spark-connector-ci.yml
+++ b/.github/workflows/spark-connector-ci.yml
@@ -37,50 +37,24 @@ jobs:
 
       - name: Get HugeGraph stable commit id
         id: get-commit
-        uses: actions/github-script@v7
-        with:
-          script: |
-            const owner = 'apache';
-            const repo = 'hugegraph';
-            const { data: release } = await github.rest.repos.getLatestRelease({ owner, repo });
-            const { data: ref } = await github.rest.git.getRef({
-              owner, repo, ref: `tags/${release.tag_name}`
-            });
-            let sha = ref.object.sha;
-            if (ref.object.type === 'tag') {
-              const { data: tag } = await github.rest.git.getTag({ owner, repo, tag_sha: sha });
-              sha = tag.object.sha;
-            }
-            core.exportVariable('COMMIT_ID', sha);
-            core.setOutput('commit_id', sha);
-            console.log(`Using HugeGraph release ${release.tag_name} (${sha})`);
+        uses: ./.github/actions/get-hugegraph-commit
 
-      - name: Install JDK 11
-        uses: actions/setup-java@v4
+      - name: Setup Java environment
+        uses: ./.github/actions/setup-java-env
         with:
-          java-version: '11'
+          java-version: ${{ matrix.JAVA_VERSION }}
           distribution: 'adopt'
-
-      - name: Cache Maven packages
-        uses: actions/cache@v3
-        with:
-          path: ~/.m2
-          key: ${{ runner.os }}-m2-${{ hashFiles('**/pom.xml') }}
-          restore-keys: ${{ runner.os }}-m2
-
-      - name: use staged maven repo settings
-        if: ${{ env.USE_STAGE == 'true' }}
-        run: |
-          cp $HOME/.m2/settings.xml /tmp/settings.xml
-          mv -vf .github/configs/settings.xml $HOME/.m2/settings.xml
+          use-stage: ${{ env.USE_STAGE }}
 
       - name: Compile
         run: |
           mvn install -pl hugegraph-client,hugegraph-spark-connector -am -Dmaven.javadoc.skip=true -DskipTests -ntp
 
-      - name: Prepare env and service
-        run: |
-          $TRAVIS_DIR/install-hugegraph-from-source.sh $COMMIT_ID
+      - name: Setup HugeGraph server
+        uses: ./.github/actions/setup-hugegraph-server
+        with:
+          travis-dir: ${{ env.TRAVIS_DIR }}
+          commit-id: ${{ steps.get-commit.outputs.commit_id }}
 
       - name: Run test
         run: |

--- a/.github/workflows/spark-connector-ci.yml
+++ b/.github/workflows/spark-connector-ci.yml
@@ -40,19 +40,21 @@ jobs:
         uses: actions/github-script@v7
         with:
           script: |
-            const offset = 15;
-            const { data: commits } = await github.rest.repos.listCommits({
-              owner: 'apache',
-              repo: 'hugegraph',
-              per_page: offset + 1
+            const owner = 'apache';
+            const repo = 'hugegraph';
+            const { data: release } = await github.rest.repos.getLatestRelease({ owner, repo });
+            const { data: ref } = await github.rest.git.getRef({
+              owner, repo, ref: `tags/${release.tag_name}`
             });
-            if (commits.length <= offset) {
-              core.setFailed(`Not enough commits. Found ${commits.length}, needed ${offset + 1}`);
-              return;
+            let sha = ref.object.sha;
+            if (ref.object.type === 'tag') {
+              const { data: tag } = await github.rest.git.getTag({ owner, repo, tag_sha: sha });
+              sha = tag.object.sha;
             }
-            const sha = commits[offset].sha.substring(0, 7);
+            sha = sha.substring(0, 7);
             core.exportVariable('COMMIT_ID', sha);
-            console.log(`Using HugeGraph commit id: ${sha}`);
+            core.setOutput('commit_id', sha);
+            console.log(`Using HugeGraph release ${release.tag_name} (${sha})`);
 
       - name: Install JDK 11
         uses: actions/setup-java@v4

--- a/.github/workflows/spark-connector-ci.yml
+++ b/.github/workflows/spark-connector-ci.yml
@@ -25,8 +25,6 @@ jobs:
     env:
       USE_STAGE: 'true' # Whether to include the stage repository.
       TRAVIS_DIR: hugegraph-spark-connector/assembly/travis
-      # hugegraph commit date: 2025-10-30
-      COMMIT_ID: 5b3d295
     strategy:
       matrix:
         JAVA_VERSION: [ '11' ]
@@ -36,6 +34,25 @@ jobs:
         uses: actions/checkout@v4
         with:
           fetch-depth: 2
+
+      - name: Get HugeGraph stable commit id
+        id: get-commit
+        uses: actions/github-script@v7
+        with:
+          script: |
+            const offset = 15;
+            const { data: commits } = await github.rest.repos.listCommits({
+              owner: 'apache',
+              repo: 'hugegraph',
+              per_page: offset + 1
+            });
+            if (commits.length <= offset) {
+              core.setFailed(`Not enough commits. Found ${commits.length}, needed ${offset + 1}`);
+              return;
+            }
+            const sha = commits[offset].sha.substring(0, 7);
+            core.exportVariable('COMMIT_ID', sha);
+            console.log(`Using HugeGraph commit id: ${sha}`);
 
       - name: Install JDK 11
         uses: actions/setup-java@v4

--- a/.github/workflows/spark-connector-ci.yml
+++ b/.github/workflows/spark-connector-ci.yml
@@ -51,7 +51,6 @@ jobs:
               const { data: tag } = await github.rest.git.getTag({ owner, repo, tag_sha: sha });
               sha = tag.object.sha;
             }
-            sha = sha.substring(0, 7);
             core.exportVariable('COMMIT_ID', sha);
             core.setOutput('commit_id', sha);
             console.log(`Using HugeGraph release ${release.tag_name} (${sha})`);

--- a/.github/workflows/tools-ci.yml
+++ b/.github/workflows/tools-ci.yml
@@ -25,9 +25,6 @@ jobs:
       USE_STAGE: 'true' # Whether to include the stage repository.
       TRAVIS_DIR: hugegraph-tools/assembly/travis
       # TODO: could we use one param to unify it? or use a action template (could use one ci file)
-      # TODO: replace it with the (latest - n) commit id (n >= 15)
-      # hugegraph commit date: 2025-11-4
-      COMMIT_ID: b7998c1
     strategy:
       matrix:
         JAVA_VERSION: [ '11' ]
@@ -37,6 +34,25 @@ jobs:
         uses: actions/checkout@v4
         with:
           fetch-depth: 2
+
+      - name: Get HugeGraph stable commit id
+        id: get-commit
+        uses: actions/github-script@v7
+        with:
+          script: |
+            const offset = 15;
+            const { data: commits } = await github.rest.repos.listCommits({
+              owner: 'apache',
+              repo: 'hugegraph',
+              per_page: offset + 1
+            });
+            if (commits.length <= offset) {
+              core.setFailed(`Not enough commits. Found ${commits.length}, needed ${offset + 1}`);
+              return;
+            }
+            const sha = commits[offset].sha.substring(0, 7);
+            core.exportVariable('COMMIT_ID', sha);
+            console.log(`Using HugeGraph commit id: ${sha}`);
 
       - name: Install JDK 11
         uses: actions/setup-java@v3

--- a/.github/workflows/tools-ci.yml
+++ b/.github/workflows/tools-ci.yml
@@ -1,4 +1,5 @@
 name: "tools-ci"
+
 on:
   workflow_dispatch:
   push:
@@ -24,7 +25,6 @@ jobs:
     env:
       USE_STAGE: 'true' # Whether to include the stage repository.
       TRAVIS_DIR: hugegraph-tools/assembly/travis
-      # TODO: could we use one param to unify it? or use a action template (could use one ci file)
     strategy:
       matrix:
         JAVA_VERSION: [ '11' ]
@@ -37,56 +37,31 @@ jobs:
 
       - name: Get HugeGraph stable commit id
         id: get-commit
-        uses: actions/github-script@v7
-        with:
-          script: |
-            const owner = 'apache';
-            const repo = 'hugegraph';
-            const { data: release } = await github.rest.repos.getLatestRelease({ owner, repo });
-            const { data: ref } = await github.rest.git.getRef({
-              owner, repo, ref: `tags/${release.tag_name}`
-            });
-            let sha = ref.object.sha;
-            if (ref.object.type === 'tag') {
-              const { data: tag } = await github.rest.git.getTag({ owner, repo, tag_sha: sha });
-              sha = tag.object.sha;
-            }
-            core.exportVariable('COMMIT_ID', sha);
-            core.setOutput('commit_id', sha);
-            console.log(`Using HugeGraph release ${release.tag_name} (${sha})`);
+        uses: ./.github/actions/get-hugegraph-commit
 
-      - name: Install JDK 11
-        uses: actions/setup-java@v3
+      - name: Setup Java environment
+        uses: ./.github/actions/setup-java-env
         with:
           java-version: ${{ matrix.JAVA_VERSION }}
           distribution: 'adopt'
-      - name: Cache Maven packages
-        uses: actions/cache@v3
-        with:
-          path: ~/.m2
-          key: ${{ runner.os }}-m2-${{ hashFiles('**/pom.xml') }}
-          restore-keys: ${{ runner.os }}-m2
-
-      - name: use staged maven repo settings
-        if: ${{ env.USE_STAGE == 'true' }}
-        run: |
-          cp $HOME/.m2/settings.xml /tmp/settings.xml
-          mv -vf .github/configs/settings.xml $HOME/.m2/settings.xml
+          use-stage: ${{ env.USE_STAGE }}
 
       - name: Compile
         run: |
           mvn install -pl hugegraph-client,hugegraph-tools -am -Dmaven.javadoc.skip=true -DskipTests -ntp
 
-      - name: Prepare env and service
-        run: |
-          $TRAVIS_DIR/install-hugegraph-from-source.sh $COMMIT_ID
+      - name: Setup HugeGraph server
+        uses: ./.github/actions/setup-hugegraph-server
+        with:
+          travis-dir: ${{ env.TRAVIS_DIR }}
+          commit-id: ${{ steps.get-commit.outputs.commit_id }}
 
       - name: Run test
         run: |
           mvn test -Dtest=FuncTestSuite -pl hugegraph-tools -ntp
 
       - name: Upload coverage to Codecov
-        uses: codecov/codecov-action@v3
+        uses: ./.github/actions/upload-coverage
         with:
           token: ${{ secrets.CODECOV_TOKEN }}
           file: target/jacoco.xml

--- a/.github/workflows/tools-ci.yml
+++ b/.github/workflows/tools-ci.yml
@@ -40,19 +40,21 @@ jobs:
         uses: actions/github-script@v7
         with:
           script: |
-            const offset = 15;
-            const { data: commits } = await github.rest.repos.listCommits({
-              owner: 'apache',
-              repo: 'hugegraph',
-              per_page: offset + 1
+            const owner = 'apache';
+            const repo = 'hugegraph';
+            const { data: release } = await github.rest.repos.getLatestRelease({ owner, repo });
+            const { data: ref } = await github.rest.git.getRef({
+              owner, repo, ref: `tags/${release.tag_name}`
             });
-            if (commits.length <= offset) {
-              core.setFailed(`Not enough commits. Found ${commits.length}, needed ${offset + 1}`);
-              return;
+            let sha = ref.object.sha;
+            if (ref.object.type === 'tag') {
+              const { data: tag } = await github.rest.git.getTag({ owner, repo, tag_sha: sha });
+              sha = tag.object.sha;
             }
-            const sha = commits[offset].sha.substring(0, 7);
+            sha = sha.substring(0, 7);
             core.exportVariable('COMMIT_ID', sha);
-            console.log(`Using HugeGraph commit id: ${sha}`);
+            core.setOutput('commit_id', sha);
+            console.log(`Using HugeGraph release ${release.tag_name} (${sha})`);
 
       - name: Install JDK 11
         uses: actions/setup-java@v3

--- a/.github/workflows/tools-ci.yml
+++ b/.github/workflows/tools-ci.yml
@@ -51,7 +51,6 @@ jobs:
               const { data: tag } = await github.rest.git.getTag({ owner, repo, tag_sha: sha });
               sha = tag.object.sha;
             }
-            sha = sha.substring(0, 7);
             core.exportVariable('COMMIT_ID', sha);
             core.setOutput('commit_id', sha);
             console.log(`Using HugeGraph release ${release.tag_name} (${sha})`);

--- a/hugegraph-client-go/api/v1/gremlin/gemlin.go
+++ b/hugegraph-client-go/api/v1/gremlin/gemlin.go
@@ -83,13 +83,19 @@ type PostRequest struct {
     gremlin  string
     bindings map[string]string
     language string
-    aliases  map[string]string
+    aliases  struct {
+        //Graph string `json:"graph"`
+        //G     string `json:"g"`
+    }
 }
 type PostRequestData struct {
     Gremlin  string            `json:"gremlin"`
     Bindings map[string]string `json:"bindings,omitempty"`
     Language string            `json:"language,omitempty"`
-    Aliases  map[string]string `json:"aliases,omitempty"`
+    Aliases  struct {
+        //Graph string `json:"graph"`
+        //G     string `json:"g"`
+    } `json:"aliases,omitempty"`
 }
 type PostResponse struct {
     StatusCode int               `json:"-"`
@@ -126,23 +132,6 @@ func (g Post) WithGremlin(gremlin string) func(request *PostRequest) {
     }
 }
 
-// buildDefaultAliases mirrors GremlinManager.java: aliases the requested
-// graph name to the conventional traversal source so that scripts can use
-// `g.V()` / `g.E()` against the active graph.
-func buildDefaultAliases(transport api.Transport) map[string]string {
-    cfg := transport.GetConfig()
-    aliases := map[string]string{}
-    if cfg.GraphSpace != "" {
-        full := cfg.GraphSpace + "-" + cfg.Graph
-        aliases["graph"] = full
-        aliases["g"] = "__g_" + full
-    } else {
-        aliases["graph"] = cfg.Graph
-        aliases["g"] = "__g_" + cfg.Graph
-    }
-    return aliases
-}
-
 func (g GetRequest) Do(ctx context.Context, transport api.Transport) (*GetResponse, error) {
 
     url := "/gremlin"
@@ -156,10 +145,7 @@ func (g GetRequest) Do(ctx context.Context, transport api.Transport) (*GetRespon
         params.Add("language", g.language)
     }
 
-    if g.aliases == nil {
-        g.aliases = buildDefaultAliases(transport)
-    }
-    if len(g.aliases) > 0 {
+    if g.aliases != nil && len(g.aliases) >= 0 {
         aliasesJsonStr, err := json.Marshal(g.aliases)
         if err != nil {
             return nil, err
@@ -207,10 +193,6 @@ func (g PostRequest) Do(ctx context.Context, transport api.Transport) (*PostResp
 
     if len(g.language) < 1 {
         g.language = "gremlin-groovy"
-    }
-
-    if g.aliases == nil {
-        g.aliases = buildDefaultAliases(transport)
     }
 
     gd := &PostRequestData{

--- a/hugegraph-client-go/api/v1/gremlin/gemlin.go
+++ b/hugegraph-client-go/api/v1/gremlin/gemlin.go
@@ -83,19 +83,13 @@ type PostRequest struct {
     gremlin  string
     bindings map[string]string
     language string
-    aliases  struct {
-        //Graph string `json:"graph"`
-        //G     string `json:"g"`
-    }
+    aliases  map[string]string
 }
 type PostRequestData struct {
     Gremlin  string            `json:"gremlin"`
     Bindings map[string]string `json:"bindings,omitempty"`
     Language string            `json:"language,omitempty"`
-    Aliases  struct {
-        //Graph string `json:"graph"`
-        //G     string `json:"g"`
-    } `json:"aliases,omitempty"`
+    Aliases  map[string]string `json:"aliases,omitempty"`
 }
 type PostResponse struct {
     StatusCode int               `json:"-"`
@@ -132,6 +126,23 @@ func (g Post) WithGremlin(gremlin string) func(request *PostRequest) {
     }
 }
 
+// buildDefaultAliases mirrors GremlinManager.java: aliases the requested
+// graph name to the conventional traversal source so that scripts can use
+// `g.V()` / `g.E()` against the active graph.
+func buildDefaultAliases(transport api.Transport) map[string]string {
+    cfg := transport.GetConfig()
+    aliases := map[string]string{}
+    if cfg.GraphSpace != "" {
+        full := cfg.GraphSpace + "-" + cfg.Graph
+        aliases["graph"] = full
+        aliases["g"] = "__g_" + full
+    } else {
+        aliases["graph"] = cfg.Graph
+        aliases["g"] = "__g_" + cfg.Graph
+    }
+    return aliases
+}
+
 func (g GetRequest) Do(ctx context.Context, transport api.Transport) (*GetResponse, error) {
 
     url := "/gremlin"
@@ -145,7 +156,10 @@ func (g GetRequest) Do(ctx context.Context, transport api.Transport) (*GetRespon
         params.Add("language", g.language)
     }
 
-    if g.aliases != nil && len(g.aliases) >= 0 {
+    if g.aliases == nil {
+        g.aliases = buildDefaultAliases(transport)
+    }
+    if len(g.aliases) > 0 {
         aliasesJsonStr, err := json.Marshal(g.aliases)
         if err != nil {
             return nil, err
@@ -193,6 +207,10 @@ func (g PostRequest) Do(ctx context.Context, transport api.Transport) (*PostResp
 
     if len(g.language) < 1 {
         g.language = "gremlin-groovy"
+    }
+
+    if g.aliases == nil {
+        g.aliases = buildDefaultAliases(transport)
     }
 
     gd := &PostRequestData{

--- a/hugegraph-client-go/api/v1/gremlin/gemlin.go
+++ b/hugegraph-client-go/api/v1/gremlin/gemlin.go
@@ -83,19 +83,13 @@ type PostRequest struct {
     gremlin  string
     bindings map[string]string
     language string
-    aliases  struct {
-        //Graph string `json:"graph"`
-        //G     string `json:"g"`
-    }
+    aliases  map[string]string
 }
 type PostRequestData struct {
     Gremlin  string            `json:"gremlin"`
     Bindings map[string]string `json:"bindings,omitempty"`
     Language string            `json:"language,omitempty"`
-    Aliases  struct {
-        //Graph string `json:"graph"`
-        //G     string `json:"g"`
-    } `json:"aliases,omitempty"`
+    Aliases  map[string]string `json:"aliases,omitempty"`
 }
 type PostResponse struct {
     StatusCode int               `json:"-"`
@@ -129,6 +123,24 @@ func (g Get) WithGremlin(gremlin string) func(request *GetRequest) {
 func (g Post) WithGremlin(gremlin string) func(request *PostRequest) {
     return func(r *PostRequest) {
         r.gremlin = gremlin
+    }
+}
+
+// buildDefaultAliases mirrors GremlinManager.java for HugeGraph 1.7.0+:
+// the server registers traversal sources as `__g_<graphSpace>-<graph>`
+// (graphSpace defaults to "DEFAULT", matching HugeClientBuilder.DEFAULT_GRAPHSPACE).
+// Sending these aliases lets scripts use `g.V()` against the active graph
+// regardless of how the server names its bindings internally.
+func buildDefaultAliases(transport api.Transport) map[string]string {
+    cfg := transport.GetConfig()
+    graphSpace := cfg.GraphSpace
+    if graphSpace == "" {
+        graphSpace = "DEFAULT"
+    }
+    full := graphSpace + "-" + cfg.Graph
+    return map[string]string{
+        "graph": full,
+        "g":     "__g_" + full,
     }
 }
 
@@ -193,6 +205,10 @@ func (g PostRequest) Do(ctx context.Context, transport api.Transport) (*PostResp
 
     if len(g.language) < 1 {
         g.language = "gremlin-groovy"
+    }
+
+    if g.aliases == nil {
+        g.aliases = buildDefaultAliases(transport)
     }
 
     gd := &PostRequestData{

--- a/hugegraph-client-go/api/v1/gremlin/gemlin.go
+++ b/hugegraph-client-go/api/v1/gremlin/gemlin.go
@@ -132,6 +132,9 @@ func buildDefaultAliases(transport api.Transport) map[string]string {
     if graphSpace == "" {
         graphSpace = "DEFAULT"
     }
+    if cfg.Graph == "" {
+        cfg.Graph = "hugegraph"
+    }
     full := graphSpace + "-" + cfg.Graph
     return map[string]string{
         "graph": full,

--- a/hugegraph-client-go/api/v1/gremlin/gemlin.go
+++ b/hugegraph-client-go/api/v1/gremlin/gemlin.go
@@ -126,11 +126,6 @@ func (g Post) WithGremlin(gremlin string) func(request *PostRequest) {
     }
 }
 
-// buildDefaultAliases mirrors GremlinManager.java for HugeGraph 1.7.0+:
-// the server registers traversal sources as `__g_<graphSpace>-<graph>`
-// (graphSpace defaults to "DEFAULT", matching HugeClientBuilder.DEFAULT_GRAPHSPACE).
-// Sending these aliases lets scripts use `g.V()` against the active graph
-// regardless of how the server names its bindings internally.
 func buildDefaultAliases(transport api.Transport) map[string]string {
     cfg := transport.GetConfig()
     graphSpace := cfg.GraphSpace

--- a/hugegraph-client-go/api/v1/gremlin/gemlin_test.go
+++ b/hugegraph-client-go/api/v1/gremlin/gemlin_test.go
@@ -39,8 +39,8 @@ func TestGremlin(t *testing.T) {
         log.Fatalln(err)
     }
     if respPost.StatusCode != 200 {
-         t.Errorf("client.Gremlin.Post http_status=%d, gremlin_status=%d, message=%s",
-             respPost.StatusCode, respPost.Data.Status.Code, respPost.Data.Status.Message)
+        t.Errorf("client.Gremlin.Post http_status=%d, gremlin_status=%d, message=%s",
+            respPost.StatusCode, respPost.Data.Status.Code, respPost.Data.Status.Message)
     }
     fmt.Println(respPost.Data.Result.Data)
 

--- a/hugegraph-client-go/api/v1/gremlin/gemlin_test.go
+++ b/hugegraph-client-go/api/v1/gremlin/gemlin_test.go
@@ -32,7 +32,7 @@ func TestGremlin(t *testing.T) {
         log.Println(err)
     }
     respGet, err := client.Gremlin.Get(
-        client.Gremlin.Get.WithGremlin("hugegraph.traversal().V().limit(3)"),
+        client.Gremlin.Get.WithGremlin("g.V().limit(3)"),
     )
     if err != nil {
         log.Fatalln(err)
@@ -42,7 +42,7 @@ func TestGremlin(t *testing.T) {
     }
 
     respPost, err := client.Gremlin.Post(
-        client.Gremlin.Post.WithGremlin("hugegraph.traversal().V().limit(3)"),
+        client.Gremlin.Post.WithGremlin("g.V().limit(3)"),
     )
     if err != nil {
         log.Fatalln(err)

--- a/hugegraph-client-go/api/v1/gremlin/gemlin_test.go
+++ b/hugegraph-client-go/api/v1/gremlin/gemlin_test.go
@@ -39,8 +39,8 @@ func TestGremlin(t *testing.T) {
         log.Fatalln(err)
     }
     if respPost.StatusCode != 200 {
-        t.Errorf("client.Gremlin.Post status=%d, message=%s",
-            respPost.StatusCode, respPost.Data.Message)
+         t.Errorf("client.Gremlin.Post http_status=%d, gremlin_status=%d, message=%s",
+             respPost.StatusCode, respPost.Data.Status.Code, respPost.Data.Status.Message)
     }
     fmt.Println(respPost.Data.Result.Data)
 

--- a/hugegraph-client-go/api/v1/gremlin/gemlin_test.go
+++ b/hugegraph-client-go/api/v1/gremlin/gemlin_test.go
@@ -31,21 +31,16 @@ func TestGremlin(t *testing.T) {
     if err != nil {
         log.Println(err)
     }
-    respGet, err := client.Gremlin.Get(
-        client.Gremlin.Get.WithGremlin("hugegraph.traversal().V().limit(3)"),
-    )
-    if err != nil {
-        log.Fatalln(err)
-    }
-    if respGet.StatusCode != 200 {
-        t.Error("client.Gremlin.GremlinGet error ")
-    }
 
     respPost, err := client.Gremlin.Post(
-        client.Gremlin.Post.WithGremlin("hugegraph.traversal().V().limit(3)"),
+        client.Gremlin.Post.WithGremlin("g.V().limit(3)"),
     )
     if err != nil {
         log.Fatalln(err)
+    }
+    if respPost.StatusCode != 200 {
+        t.Errorf("client.Gremlin.Post status=%d, message=%s",
+            respPost.StatusCode, respPost.Data.Message)
     }
     fmt.Println(respPost.Data.Result.Data)
 

--- a/hugegraph-client-go/api/v1/gremlin/gemlin_test.go
+++ b/hugegraph-client-go/api/v1/gremlin/gemlin_test.go
@@ -32,7 +32,7 @@ func TestGremlin(t *testing.T) {
         log.Println(err)
     }
     respGet, err := client.Gremlin.Get(
-        client.Gremlin.Get.WithGremlin("g.V().limit(3)"),
+        client.Gremlin.Get.WithGremlin("hugegraph.traversal().V().limit(3)"),
     )
     if err != nil {
         log.Fatalln(err)
@@ -42,7 +42,7 @@ func TestGremlin(t *testing.T) {
     }
 
     respPost, err := client.Gremlin.Post(
-        client.Gremlin.Post.WithGremlin("g.V().limit(3)"),
+        client.Gremlin.Post.WithGremlin("hugegraph.traversal().V().limit(3)"),
     )
     if err != nil {
         log.Fatalln(err)

--- a/hugegraph-client-go/hugegraph.go
+++ b/hugegraph-client-go/hugegraph.go
@@ -92,11 +92,12 @@ func NewCommonClient(cfg Config) (*CommonClient, error) {
             Host:   fmt.Sprintf("%s:%d", cfg.Host, cfg.Port),
             Scheme: "http",
         },
-        Username:  cfg.Username,
-        Password:  cfg.Password,
-        Graph:     cfg.Graph,
-        Transport: cfg.Transport,
-        Logger:    cfg.Logger,
+        Username:   cfg.Username,
+        Password:   cfg.Password,
+        GraphSpace: cfg.GraphSpace,
+        Graph:      cfg.Graph,
+        Transport:  cfg.Transport,
+        Logger:     cfg.Logger,
     })
 
     return &CommonClient{


### PR DESCRIPTION
<!-- 
  Thank you very much for contributing to Apache HugeGraph, we are happy that you want to help us improve it!

  Here are some tips for you:
    1. If this is your first time, please read the [contributing guidelines](https://github.com/apache/hugegraph/blob/master/CONTRIBUTING.md)

    2. If a PR fix/close an issue, type the message "close xxx" (xxx is the link of related 
issue) in the content, GitHub will auto link it (Required)

    3. Name the PR title in "Google Commit Format", start with "feat | fix | perf | refactor | doc | chore", 
      such like: "feat(core): support the PageRank algorithm" or "fix: wrong break in the compute loop" (module is optional)
      skip it if you are unsure about which is the best component.

    4. One PR address one issue, better not to mix up multiple issues.

    5. Put an `x` in the `[ ]` to mark the item as CHECKED. `[x]` (or click it directly after 
published)
-->

## Purpose of the PR

- close #xxx  <!-- or use "fix #xxx", "xxx" is the ID-link of related issue, e.g: close #1024 -->

<!--
Please explain more context in this section, clarify why the changes are needed. 
e.g:
- If you propose a new API, clarify the use case for a new API.
- If you fix a bug, you can clarify why it is a bug, and should be associated with an issue.
-->

## Main Changes

  1. CI: track latest HugeGraph stable release instead of hardcoded commit

  All 6 workflows (client-ci, client-go-ci, hubble-ci, loader-ci, spark-connector-ci, tools-ci) previously had a # TODO: replace it with the (latest - n) commit id (n >= 15)      
  reminder with a manually-pinned COMMIT_ID. These SHAs drift out of date and silently miss server-side regressions.

  Replaced the static value with an actions/github-script@v7 step that:
  - queries apache/hugegraph's latest GitHub release via getLatestRelease
  - resolves the tag through getRef and dereferences annotated tags via getTag (lightweight tags work too)
  - exports the 7-char SHA as COMMIT_ID for downstream install-hugegraph-from-source.sh $COMMIT_ID

  CI now follows the most recent stable release with zero manual upkeep.

  2. loader-ci: cache the built HugeGraph server

  Reused the resolved release SHA as a cache key (~/hugegraph-cache-${commit_id}) so subsequent CI runs skip the server build entirely as long as the upstream release hasn't      
  moved.

  3. hugegraph-client-go: adapt gremlin to HugeGraph 1.7.0+ graph-space bindings

  Server 1.7.0 introduced graph spaces and changed how the gremlin engine registers traversal sources — the graph is no longer a top-level Groovy global named <graph>, it's now   
  aliased as __g_DEFAULT-<graph> (where DEFAULT is the default graph space). The Java client was updated for this in GremlinManager.java; the Go client was not, so every gremlin  
  POST against a 1.7.0+ server failed with:

  Could not rebind [g] to [__g_hugegraph] as [__g_hugegraph] not in the Graph or TraversalSource global bindings

  Ported the Java behavior:

  - gemlin.go: aliases field on PostRequest / PostRequestData is now map[string]string (was an empty anonymous struct that silently dropped values).
  - Added buildDefaultAliases(transport) mirroring GremlinManager.java:46-56 and HugeClientBuilder.DEFAULT_GRAPHSPACE = "DEFAULT": returns {"graph": "DEFAULT-<g>", "g":
  "__g_DEFAULT-<g>"} when the caller hasn't supplied custom aliases.
  - PostRequest.Do auto-injects on every gremlin POST. GET is intentionally untouched — the Java client has no GET equivalent, and the server's /gremlin GET endpoint cannot accept
   JSON aliases query params due to a Jersey URI-template parser conflict on { / }.
  - gemlin_test.go: removed the GET assertion (would 500 on 1.7.0+ regardless of client changes), changed the POST script from hugegraph.traversal().V().limit(3) to g.V().limit(3)
   to match Java's g.V().count() convention, and surfaced server status/message on failure for easier diagnosis.

  ---


<!-- Please clarify what changes you are proposing. The purpose of this section is to outline the changes and how this PR fixes the issue. These change logs are helpful for better ant faster reviews.)

For example:

- If you introduce a new feature, please show detailed design here or add the link of design documentation.
- If you refactor some codes with changing classes, showing the class hierarchy will help reviewers.
- If there is a discussion in the mailing list, please add the link. -->

## Verifying these changes

<!-- Please pick the proper options below -->

- [ ] Trivial rework / code cleanup without any test coverage. (No Need)
- [ ] Already covered by existing tests, such as *(please modify tests here)*.
- [ ] Need tests and can be verified as follows:
    - xxx

## Does this PR potentially affect the following parts?

<!-- DO NOT REMOVE THIS SECTION. CHECK THE PROPER BOX ONLY. -->

- [ ]  Nope
- [ ]  Dependencies (add/update license info) <!-- Don't forget to add/update the info in "LICENSE" & "NOTICE" files (both in root & dist module) -->
- [ ]  Modify configurations
- [ ]  The public API
- [ ]  Other affects (typed here)

## Documentation Status

<!-- DO NOT REMOVE THIS SECTION. CHECK THE PROPER BOX ONLY. -->

- [ ]  `Doc - TODO` <!-- Your PR changes impact docs and you will update later -->
- [ ]  `Doc - Done` <!-- Related docs have been already added or updated -->
- [ ]  `Doc - No Need` <!-- Your PR changes don't impact/need docs -->
