### PR TITLE
fix(loader): fix thread-safety issue in DateUtil with concurrent date parsing

### DIFF
--- a/hugegraph-loader/src/main/java/org/apache/hugegraph/loader/util/DateUtil.java
+++ b/hugegraph-loader/src/main/java/org/apache/hugegraph/loader/util/DateUtil.java
@@ -18,16 +18,15 @@
 package org.apache.hugegraph.loader.util;
 
 import java.util.Date;
-import java.util.Map;
 import java.util.TimeZone;
-import java.util.concurrent.ConcurrentHashMap;
 
 import org.apache.hugegraph.date.SafeDateFormat;
 import org.apache.hugegraph.loader.constant.Constants;
 
 public final class DateUtil {
 
-    private static final Map<String, SafeDateFormat> DATE_FORMATS = new ConcurrentHashMap<>();
+    private static final ThreadLocal<java.util.HashMap<String, SafeDateFormat>> DATE_FORMATS =
+            ThreadLocal.withInitial(java.util.HashMap::new);
 
     public static Date parse(String source, String df) {
         return parse(source, df, Constants.TIME_ZONE);
@@ -41,13 +40,11 @@ public final class DateUtil {
     }
 
     private static SafeDateFormat getDateFormat(String df) {
-        SafeDateFormat dateFormat = DATE_FORMATS.get(df);
+        java.util.HashMap<String, SafeDateFormat> formats = DATE_FORMATS.get();
+        SafeDateFormat dateFormat = formats.get(df);
         if (dateFormat == null) {
             dateFormat = new SafeDateFormat(df);
-            SafeDateFormat previous = DATE_FORMATS.putIfAbsent(df, dateFormat);
-            if (previous != null) {
-                dateFormat = previous;
-            }
+            formats.put(df, dateFormat);
         }
         return dateFormat;
     }
@@ -58,7 +55,9 @@ public final class DateUtil {
     }
 
     public static String now(String df) {
-        return getDateFormat(df).format(new Date());
+        SafeDateFormat dateFormat = getDateFormat(df);
+        dateFormat.setTimeZone(Constants.TIME_ZONE);
+        return dateFormat.format(new Date());
     }
 
     public static boolean checkTimeZone(String timeZone) {

--- a/hugegraph-loader/src/main/java/org/apache/hugegraph/loader/util/DateUtil.java
+++ b/hugegraph-loader/src/main/java/org/apache/hugegraph/loader/util/DateUtil.java
@@ -18,6 +18,7 @@
 package org.apache.hugegraph.loader.util;
 
 import java.util.Date;
+import java.util.HashMap;
 import java.util.TimeZone;
 
 import org.apache.hugegraph.date.SafeDateFormat;
@@ -25,8 +26,8 @@ import org.apache.hugegraph.loader.constant.Constants;
 
 public final class DateUtil {
 
-    private static final ThreadLocal<java.util.HashMap<String, SafeDateFormat>> DATE_FORMATS =
-            ThreadLocal.withInitial(java.util.HashMap::new);
+    private static final ThreadLocal<HashMap<String, SafeDateFormat>> DATE_FORMATS =
+            ThreadLocal.withInitial(HashMap::new);
 
     public static Date parse(String source, String df) {
         return parse(source, df, Constants.TIME_ZONE);
@@ -34,13 +35,12 @@ public final class DateUtil {
 
     public static Date parse(String source, String df, String timeZone) {
         SafeDateFormat dateFormat = getDateFormat(df);
-        // parse date with specified timezone
         dateFormat.setTimeZone(timeZone);
         return dateFormat.parse(source);
     }
 
     private static SafeDateFormat getDateFormat(String df) {
-        java.util.HashMap<String, SafeDateFormat> formats = DATE_FORMATS.get();
+        HashMap<String, SafeDateFormat> formats = DATE_FORMATS.get();
         SafeDateFormat dateFormat = formats.get(df);
         if (dateFormat == null) {
             dateFormat = new SafeDateFormat(df);

--- a/hugegraph-loader/src/test/java/org/apache/hugegraph/loader/test/unit/DateUtilTest.java
+++ b/hugegraph-loader/src/test/java/org/apache/hugegraph/loader/test/unit/DateUtilTest.java
@@ -17,12 +17,27 @@
 
 package org.apache.hugegraph.loader.test.unit;
 
+import java.util.Date;
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
+import java.util.concurrent.atomic.AtomicInteger;
+
 import org.apache.hugegraph.loader.util.DateUtil;
 import org.junit.Test;
 
 import org.apache.hugegraph.testutil.Assert;
 
 public class DateUtilTest {
+
+    @Test
+    public void testNowUsesDefaultTimeZone() {
+        String pattern = "Z";
+
+        DateUtil.parse("1970-01-01 +0000", "yyyy-MM-dd Z", "GMT");
+
+        Assert.assertEquals("+0800", DateUtil.now(pattern));
+    }
 
     @Test
     public void testCheckTimeZone() {
@@ -69,5 +84,39 @@ public class DateUtilTest {
         Assert.assertFalse(DateUtil.checkTimeZone("GMT+24:00"));
         // minutes 00-59 only
         Assert.assertFalse(DateUtil.checkTimeZone("GMT+13:60"));
+    }
+
+    @Test
+    public void testConcurrentParseDateWithDifferentTimeZones() throws InterruptedException {
+        int threads = 10;
+        int iterations = 100;
+        ExecutorService executor = Executors.newFixedThreadPool(threads);
+        CountDownLatch latch = new CountDownLatch(threads);
+        AtomicInteger errors = new AtomicInteger(0);
+
+        String dateStr = "2024-01-15 12:00:00";
+        String pattern = "yyyy-MM-dd HH:mm:ss";
+
+        for (int i = 0; i < threads; i++) {
+            final int threadId = i;
+            executor.submit(() -> {
+                try {
+                    String timeZone = threadId % 2 == 0 ? "GMT+8" : "GMT+0";
+                    for (int j = 0; j < iterations; j++) {
+                        Date result = DateUtil.parse(dateStr, pattern, timeZone);
+                        if (result == null) {
+                            errors.incrementAndGet();
+                        }
+                    }
+                } finally {
+                    latch.countDown();
+                }
+            });
+        }
+
+        latch.await();
+        executor.shutdown();
+
+        Assert.assertEquals(0, errors.get());
     }
 }

--- a/hugegraph-loader/src/test/java/org/apache/hugegraph/loader/test/unit/DateUtilTest.java
+++ b/hugegraph-loader/src/test/java/org/apache/hugegraph/loader/test/unit/DateUtilTest.java
@@ -33,9 +33,7 @@ public class DateUtilTest {
     @Test
     public void testNowUsesDefaultTimeZone() {
         String pattern = "Z";
-
-        DateUtil.parse("1970-01-01 +0000", "yyyy-MM-dd Z", "GMT");
-
+        DateUtil.parse("+0000", pattern, "GMT");
         Assert.assertEquals("+0800", DateUtil.now(pattern));
     }
 
@@ -96,18 +94,24 @@ public class DateUtilTest {
 
         String dateStr = "2024-01-15 12:00:00";
         String pattern = "yyyy-MM-dd HH:mm:ss";
+        long expectedEpochGMT8 = DateUtil.parse(dateStr, pattern, "GMT+8").getTime();
+        long expectedEpochGMT0 = DateUtil.parse(dateStr, pattern, "GMT+0").getTime();
+        long expectedDiff = 8 * 60 * 60 * 1000;
 
         for (int i = 0; i < threads; i++) {
             final int threadId = i;
             executor.submit(() -> {
                 try {
                     String timeZone = threadId % 2 == 0 ? "GMT+8" : "GMT+0";
+                    long expectedEpoch = threadId % 2 == 0 ? expectedEpochGMT8 : expectedEpochGMT0;
                     for (int j = 0; j < iterations; j++) {
                         Date result = DateUtil.parse(dateStr, pattern, timeZone);
-                        if (result == null) {
+                        if (result == null || result.getTime() != expectedEpoch) {
                             errors.incrementAndGet();
                         }
                     }
+                } catch (Exception e) {
+                    errors.incrementAndGet();
                 } finally {
                     latch.countDown();
                 }
@@ -118,5 +122,6 @@ public class DateUtilTest {
         executor.shutdown();
 
         Assert.assertEquals(0, errors.get());
+        Assert.assertEquals(expectedDiff, expectedEpochGMT0 - expectedEpochGMT8);
     }
 }


### PR DESCRIPTION
<!-- 
  Thank you very much for contributing to Apache HugeGraph, we are happy that you want to help us improve it!

  Here are some tips for you:
    1. If this is your first time, please read the [contributing guidelines](https://github.com/apache/hugegraph/blob/master/CONTRIBUTING.md)

    2. If a PR fix/close an issue, type the message "close xxx" (xxx is the link of related 
issue) in the content, GitHub will auto link it (Required)

    3. Name the PR title in "Google Commit Format", start with "feat | fix | perf | refactor | doc | chore", 
      such like: "feat(core): support the PageRank algorithm" or "fix: wrong break in the compute loop" (module is optional)
      skip it if you are unsure about which is the best component.

    4. One PR address one issue, better not to mix up multiple issues.

    5. Put an `x` in the `[ ]` to mark the item as CHECKED. `[x]` (or click it directly after 
published)
-->

## Purpose of the PR

- close #733   <!-- or use "fix #xxx", "xxx" is the ID-link of related issue, e.g: close #1024 -->

<!--
Please explain more context in this section, clarify why the changes are needed. 
e.g:
- If you propose a new API, clarify the use case for a new API.
- If you fix a bug, you can clarify why it is a bug, and should be associated with an issue.
-->

## Main Changes

Replace ConcurrentHashMap with ThreadLocal<HashMap> so each thread has its
own isolated SafeDateFormat instances, eliminating race conditions.

Ensure DateUtil.now() explicitly sets the default timezone before
formatting to avoid timezone pollution from previous parse() calls.

## Verifying these changes

<!-- Please pick the proper options below -->

- [ ] Trivial rework / code cleanup without any test coverage. (No Need)
- [ ] Already covered by existing tests, such as *(please modify tests here)*.
- [x] Need tests and can be verified as follows:
    - Dtest=DateUtilTest

## Does this PR potentially affect the following parts?

<!-- DO NOT REMOVE THIS SECTION. CHECK THE PROPER BOX ONLY. -->

- [x]  Nope
- [ ]  Dependencies (add/update license info) <!-- Don't forget to add/update the info in "LICENSE" & "NOTICE" files (both in root & dist module) -->
- [ ]  Modify configurations
- [ ]  The public API
- [ ]  Other affects (typed here)

## Documentation Status

<!-- DO NOT REMOVE THIS SECTION. CHECK THE PROPER BOX ONLY. -->

- [ ]  `Doc - TODO` <!-- Your PR changes impact docs and you will update later -->
- [ ]  `Doc - Done` <!-- Related docs have been already added or updated -->
- [x]  `Doc - No Need` <!-- Your PR changes don't impact/need docs -->
