### PR TITLE
perf(docker): avoid emulated Java builds

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,39 @@
+# Licensed to the Apache Software Foundation (ASF) under one or more
+# contributor license agreements.  See the NOTICE file distributed with
+# this work for additional information regarding copyright ownership.
+# The ASF licenses this file to You under the Apache License, Version 2.0
+# (the "License"); you may not use this file except in compliance with
+# the License.  You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# Version-control and local development metadata
+.git
+.github
+.idea
+.vscode
+.codex-task
+**/.DS_Store
+
+# Build outputs and dependency caches
+**/target
+**/node_modules
+**/.cache
+
+# Modules not used by the Hubble image build. Keep the Maven module POMs so
+# the root reactor can still be parsed, and keep release docs used by hubble-dist.
+hugegraph-client-go
+hugegraph-spark-connector/**
+!hugegraph-spark-connector/pom.xml
+hugegraph-tools/**
+!hugegraph-tools/pom.xml
+hugegraph-dist/**
+!hugegraph-dist/pom.xml
+!hugegraph-dist/release-docs/
+!hugegraph-dist/release-docs/**

--- a/README.md
+++ b/README.md
@@ -406,11 +406,27 @@ docker run --rm \
 Build images locally:
 ```bash
 # Loader
-cd hugegraph-loader && docker build -t hugegraph/hugegraph-loader:latest .
+docker build -f hugegraph-loader/Dockerfile \
+  -t hugegraph/hugegraph-loader:latest .
 
 # Hubble
-cd hugegraph-hubble && docker build -t hugegraph/hugegraph-hubble:latest .
+docker build -f hugegraph-hubble/Dockerfile \
+  -t hugegraph/hugegraph-hubble:latest .
 ```
+
+Multi-platform builds use BuildKit's automatic platform arguments. The Maven
+and Node build stages run on `$BUILDPLATFORM`, while the final JRE stage uses
+`$TARGETPLATFORM`. Java bytecode and frontend assets are architecture-neutral,
+so they are built once without QEMU. Target-stage package installation still
+runs for each architecture.
+
+This optimization applies only to architecture-independent build outputs. A
+component that compiles native code must use a target-platform build stage or
+separate platform stages. Loader and Hubble packaging is validated on arm64;
+native dependencies must still be audited. Loader includes arm64 variants for
+Snappy, LZ4, Commons Crypto, and gRPC tcnative. Some optional legacy HBase and
+Jansi natives remain x86-only, so their fallback paths require target-runtime
+validation when those optional features are used.
 
 ## Documentation
 

--- a/hugegraph-hubble/Dockerfile
+++ b/hugegraph-hubble/Dockerfile
@@ -15,13 +15,12 @@
 # limitations under the License.
 #
 
-FROM maven:3.9.0-eclipse-temurin-11 AS build
+FROM --platform=$BUILDPLATFORM maven:3.9.0-eclipse-temurin-11 AS build
 
 ENV NODE_OPTIONS=--dns-result-order=ipv4first
 
 ARG MAVEN_ARGS
 
-COPY . /pkg
 WORKDIR /pkg
 
 RUN set -x \
@@ -29,6 +28,8 @@ RUN set -x \
     && apt-get install curl -yq \
     && apt-get clean \
     && rm -rf /var/lib/apt/lists/*
+
+COPY . /pkg
 
 RUN set -x \
     && mvn install $MAVEN_ARGS -pl hugegraph-client,hugegraph-loader -am -Dmaven.javadoc.skip=true -DskipTests -ntp \

--- a/hugegraph-loader/Dockerfile
+++ b/hugegraph-loader/Dockerfile
@@ -15,7 +15,7 @@
 # limitations under the License.
 #
 
-FROM maven:3.9.0-eclipse-temurin-11 AS build
+FROM --platform=$BUILDPLATFORM maven:3.9.0-eclipse-temurin-11 AS build
 
 COPY . /pkg
 WORKDIR /pkg
@@ -23,17 +23,10 @@ WORKDIR /pkg
 ARG MAVEN_ARGS
 
 RUN set -x \
-    && mvn install $MAVEN_ARGS -pl hugegraph-client,hugegraph-loader -am -Dmaven.javadoc.skip=true -DskipTests -ntp
-
-RUN set -x \
-    && cd /pkg/hugegraph-loader/ \
-    && echo "$(ls)" \
-    && mvn clean package $MAVEN_ARGS -DskipTests
+    && mvn clean package $MAVEN_ARGS -pl hugegraph-client,hugegraph-loader -am \
+       -Dmaven.javadoc.skip=true -DskipTests -ntp
 
 FROM eclipse-temurin:11-jre-jammy
-
-COPY --from=build /pkg/hugegraph-loader/apache-hugegraph-loader-*/ /loader
-WORKDIR /loader/
 
 RUN set -x \
     && apt-get -q update \
@@ -44,6 +37,9 @@ RUN set -x \
        lsof \
     && apt-get clean \
     && rm -rf /var/lib/apt/lists/*
+
+COPY --from=build /pkg/hugegraph-loader/apache-hugegraph-loader-*/ /loader
+WORKDIR /loader/
 
 VOLUME /loader
 


### PR DESCRIPTION
## Summary

- build Hubble and Loader Java/frontend artifacts once on the native BuildKit platform
- keep amd64/arm64 runtime stages target-platform specific
- collapse Loader duplicate Maven packaging into one reactor build
- improve Docker layer ordering and reduce the build context
- document BUILDPLATFORM/TARGETPLATFORM and native dependency boundaries

## Measured validation

- Hubble multi-platform build: 147.5 minutes before, 8.8 minutes after
- Loader multi-platform run: roughly 30-40 minutes before, 2.9 minutes after

Read-only validation runs:
- https://github.com/hugegraph/actions/actions/runs/29187794349
- https://github.com/hugegraph/actions/actions/runs/29188191489

Companion workflow/cache changes: hugegraph/actions#22.

## Verification

- equivalent JDK 11 Hubble and Loader builds passed
- Loader distribution file set matched the previous build and Loader --help ran on arm64
- native JAR contents were audited for arm64 variants and optional legacy risks documented
- git diff --check passed
- independent cross-repository review passed